### PR TITLE
Reader based public API, fix tests

### DIFF
--- a/.github/workflows/buildbot.yml
+++ b/.github/workflows/buildbot.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest,windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -24,7 +27,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Check with Gradle
-        run: ./gradlew --no-daemon check detektMain jacocoTestReport coverallsJacoco
+        run: ./gradlew --no-daemon check jacocoTestReport coverallsJacoco
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF to Github using the upload-sarif action

--- a/api/stalla.api
+++ b/api/stalla.api
@@ -3,6 +3,7 @@ public final class dev/stalla/PodcastRssParser {
 	public static final fun parse (Ljava/io/File;)Ldev/stalla/model/Podcast;
 	public static final fun parse (Ljava/io/InputStream;)Ldev/stalla/model/Podcast;
 	public static final fun parse (Ljava/io/InputStream;Ljava/lang/String;)Ldev/stalla/model/Podcast;
+	public static final fun parse (Ljava/io/Reader;)Ldev/stalla/model/Podcast;
 	public static final fun parse (Ljava/lang/String;)Ldev/stalla/model/Podcast;
 	public static final fun parse (Lorg/w3c/dom/Document;)Ldev/stalla/model/Podcast;
 	public static final fun parse (Lorg/xml/sax/InputSource;)Ldev/stalla/model/Podcast;
@@ -12,6 +13,7 @@ public final class dev/stalla/PodcastRssWriter {
 	public static final field INSTANCE Ldev/stalla/PodcastRssWriter;
 	public static final fun write (Ldev/stalla/model/Podcast;Ljava/io/File;)V
 	public static final fun write (Ldev/stalla/model/Podcast;Ljava/io/OutputStream;)V
+	public static final fun write (Ldev/stalla/model/Podcast;Ljava/io/Writer;)V
 }
 
 public abstract interface class dev/stalla/builder/AtomBuilder : dev/stalla/builder/Builder {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,4 +112,11 @@ tasks {
         // Required for type resolution
         jvmTarget = "1.8"
     }
+
+    afterEvaluate {
+        // Needs to happen lazily as :detektMain is added late
+        named("check") {
+            dependsOn(named<Detekt>("detektMain"))
+        }
+    }
 }

--- a/src/main/kotlin/dev/stalla/PodcastRssParser.kt
+++ b/src/main/kotlin/dev/stalla/PodcastRssParser.kt
@@ -30,6 +30,7 @@ import org.xml.sax.SAXException
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
+import java.io.Reader
 import javax.xml.parsers.DocumentBuilder
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -114,7 +115,21 @@ public object PodcastRssParser {
      */
     @JvmStatic
     @Throws(IOException::class, SAXException::class)
-    public fun parse(file: File): Podcast? = parse(builder.parse(file))
+    public fun parse(file: File): Podcast? = file.bufferedReader().use { reader -> parse(reader) }
+
+    /**
+     * Parse the content of the given [Reader] as an XML document
+     * and return a [Podcast] if the XML document is an RSS feed.
+     *
+     * @param reader Reader containing the content to be parsed.
+     * @return A [Podcast] if the XML document behind the reader is an RSS document, otherwise `null`.
+     * @throws IOException If any IO errors occur.
+     * @throws SAXException If any XML parsing errors occur.
+     * @throws NullPointerException If [reader] is `null`.
+     */
+    @JvmStatic
+    @Throws(IOException::class, SAXException::class)
+    public fun parse(reader: Reader): Podcast? = parse(InputSource(reader))
 
     /**
      * Parse the content of the given input source as an XML document

--- a/src/main/kotlin/dev/stalla/PodcastRssParser.kt
+++ b/src/main/kotlin/dev/stalla/PodcastRssParser.kt
@@ -71,13 +71,13 @@ public object PodcastRssParser {
      */
     @JvmStatic
     @Throws(IOException::class, SAXException::class)
-    public fun parse(uri: String): Podcast? = parse(builder.parse(uri))
+    public fun parse(uri: String): Podcast? = parse(InputSource(uri))
 
     /**
      * Parse the content of the given input stream as an XML document
      * and return a [Podcast] if the XML document is an RSS feed.
      *
-     * @param inputStream InputStream containing the content to be parsed.
+     * @param inputStream InputStream containing the content to be parsed. It will not be closed automatically.
      * @return A [Podcast] if the XML document behind the input stream is an RSS document, otherwise `null`.
      * @throws IOException If any IO errors occur.
      * @throws SAXException If any XML parsing errors occur.
@@ -85,7 +85,7 @@ public object PodcastRssParser {
      */
     @JvmStatic
     @Throws(IOException::class, SAXException::class)
-    public fun parse(inputStream: InputStream): Podcast? = parse(builder.parse(inputStream))
+    public fun parse(inputStream: InputStream): Podcast? = inputStream.bufferedReader().use { parse(it) }
 
     /**
      * Parse the content of the given input stream as an XML document
@@ -101,7 +101,7 @@ public object PodcastRssParser {
     @JvmStatic
     @Throws(IOException::class, SAXException::class)
     public fun parse(inputStream: InputStream, systemId: String?): Podcast? =
-        parse(builder.parse(inputStream, systemId))
+        parse(InputSource(inputStream).also { it.systemId = systemId })
 
     /**
      * Parse the content of the given file as an XML document
@@ -115,13 +115,13 @@ public object PodcastRssParser {
      */
     @JvmStatic
     @Throws(IOException::class, SAXException::class)
-    public fun parse(file: File): Podcast? = file.bufferedReader().use { reader -> parse(reader) }
+    public fun parse(file: File): Podcast? = file.bufferedReader().use { parse(it) }
 
     /**
      * Parse the content of the given [Reader] as an XML document
      * and return a [Podcast] if the XML document is an RSS feed.
      *
-     * @param reader Reader containing the content to be parsed.
+     * @param reader Reader containing the content to be parsed. It will not be closed automatically.
      * @return A [Podcast] if the XML document behind the reader is an RSS document, otherwise `null`.
      * @throws IOException If any IO errors occur.
      * @throws SAXException If any XML parsing errors occur.
@@ -135,7 +135,7 @@ public object PodcastRssParser {
      * Parse the content of the given input source as an XML document
      * and return a [Podcast] if the XML document is an RSS feed.
      *
-     * @param inputSource InputSource containing the content to be parsed.
+     * @param inputSource InputSource containing the content to be parsed. It will not be closed automatically.
      * @return A [Podcast] if the XML document behind the input source is an RSS document, otherwise null.
      * @throws IOException If any IO errors occur.
      * @throws SAXException If any XML parsing errors occur.

--- a/src/main/kotlin/dev/stalla/PodcastRssWriter.kt
+++ b/src/main/kotlin/dev/stalla/PodcastRssWriter.kt
@@ -20,6 +20,7 @@ import org.w3c.dom.Element
 import java.io.File
 import java.io.IOException
 import java.io.OutputStream
+import java.io.Writer
 import javax.xml.transform.OutputKeys
 import javax.xml.transform.TransformerException
 import javax.xml.transform.TransformerFactory
@@ -71,15 +72,14 @@ public object PodcastRssWriter {
     @JvmStatic
     @Throws(IOException::class, TransformerException::class)
     public fun write(podcast: Podcast, file: File) {
-        file.outputStream()
-            .use { outputStream -> write(podcast, outputStream) }
+        file.bufferedWriter().use { writer -> write(podcast, writer) }
     }
 
     /**
      * Writes a [Podcast] to a [OutputStream] as an RSS feed.
      *
      * @param podcast The [Podcast] to write out.
-     * @param stream The [OutputStream] to write to.
+     * @param stream The [OutputStream] to write to. It will not be closed automatically.
      * @throws IOException If any IO errors occur.
      * @throws TransformerException If an unrecoverable error occurs during the course of the transformation to XML.
      * @throws NullPointerException If [podcast] or [stream] is `null`.
@@ -87,13 +87,25 @@ public object PodcastRssWriter {
     @JvmStatic
     @Throws(IOException::class, TransformerException::class)
     public fun write(podcast: Podcast, stream: OutputStream) {
+        stream.bufferedWriter().use { writer -> write(podcast, writer) }
+    }
+
+    /**
+     * Writes a [Podcast] to a [Writer] as an RSS feed.
+     *
+     * @param podcast The [Podcast] to write out.
+     * @param writer The [Writer] to write to. It will not be closed automatically.
+     * @throws IOException If any IO errors occur.
+     * @throws TransformerException If an unrecoverable error occurs during the course of the transformation to XML.
+     * @throws NullPointerException If [podcast] or [writer] is `null`.
+     */
+    @JvmStatic
+    @Throws(IOException::class, TransformerException::class)
+    public fun write(podcast: Podcast, writer: Writer) {
         val document = writeToDocument(podcast)
         val source = DOMSource(document)
 
-        stream.bufferedWriter().use { writer ->
-            val result = StreamResult(writer)
-            transformer.transform(source, result)
-        }
+        transformer.transform(source, StreamResult(writer))
     }
 
     private fun writeToDocument(podcast: Podcast): Document {

--- a/src/test/java/dev/stalla/PodcastRssParserInteropTest.java
+++ b/src/test/java/dev/stalla/PodcastRssParserInteropTest.java
@@ -11,6 +11,7 @@ import dev.stalla.model.podcastindex.Soundbite;
 import dev.stalla.model.podcastindex.Transcript;
 import dev.stalla.model.podlove.SimpleChapter;
 import dev.stalla.model.rss.RssCategory;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -111,8 +113,21 @@ public class PodcastRssParserInteropTest {
 
     @Test
     @DisplayName("should fail to parse a File that cannot be read")
-    void failOnFileNotExists(@TemporaryFile File file) {
-        assertThrows(IOException.class, () -> PodcastRssParser.parse(toUnReadableFile(file)));
+    void failWhenReaderThrows() {
+        var throwingReader = new Reader() {
+
+            @Override
+            public int read(@NotNull char[] cbuf, int off, int len) throws IOException {
+                throw new IOException("This is meant to happen");
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException("This is meant to happen");
+            }
+        };
+
+        assertThrows(IOException.class, () -> PodcastRssParser.parse(throwingReader));
     }
 
     @Test

--- a/src/test/java/dev/stalla/PodcastRssWriterInteropTest.java
+++ b/src/test/java/dev/stalla/PodcastRssWriterInteropTest.java
@@ -1,6 +1,7 @@
 package dev.stalla;
 
 import dev.stalla.model.Podcast;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +11,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.lang.reflect.Method;
 
 import static dev.stalla.TestUtilKt.declaresException;
@@ -19,18 +21,19 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("ConstantConditions")
 @ExtendWith({TemporaryFileParameterResolver.class})
 public class PodcastRssWriterInteropTest {
 
     @Test
-    @DisplayName("should fail to write a null Podcast to a File")
+    @DisplayName("should throw a NullPointerException when trying to write a null Podcast to a File")
     void failOnNullPodcastToFile(@TemporaryFile File file) {
         final Podcast podcast = null;
         assertThrows(NullPointerException.class, () -> PodcastRssWriter.write(podcast, file));
     }
 
     @Test
-    @DisplayName("should fail to write a null Podcast to an OutputStream")
+    @DisplayName("should throw a NullPointerException when trying to write a null Podcast to an OutputStream")
     void failOnNullPodcastToOutputStream(@TemporaryFile File file) throws IOException {
         final Podcast podcast = null;
         final OutputStream outputStream = new FileOutputStream(file);
@@ -38,7 +41,7 @@ public class PodcastRssWriterInteropTest {
     }
 
     @Test
-    @DisplayName("should fail to write a Podcast to a null File")
+    @DisplayName("should throw a NullPointerException when trying to write a Podcast to a null File")
     void failOnPodcastToNullFile() {
         final Podcast podcast = aPodcast();
         final File file = null;
@@ -53,7 +56,22 @@ public class PodcastRssWriterInteropTest {
     }
 
     @Test
-    @DisplayName("should fail to write a Podcast to a null OutputStream")
+    @DisplayName("should throw a NullPointerException when trying to write a Podcast to a null Writer")
+    void failOnPodcastToNullWriter() {
+        final Podcast podcast = aPodcast();
+        final Writer writer = null;
+        assertThrows(NullPointerException.class, () -> PodcastRssWriter.write(podcast, writer));
+    }
+
+    @Test
+    @DisplayName("should throw an TransformerException when writing a Podcast to a writer that throws")
+    void failWhenWriterThrows() {
+        final Podcast podcast = aPodcast();
+        assertThrows(TransformerException.class, () -> PodcastRssWriter.write(podcast, createThrowingWriter()));
+    }
+
+    @Test
+    @DisplayName("should throw a NullPointerException when trying to write a Podcast to a null OutputStream")
     void failOnPodcastToNullOutputStream() {
         final Podcast podcast = aPodcast();
         final OutputStream outputStream = null;
@@ -100,6 +118,26 @@ public class PodcastRssWriterInteropTest {
         final OutputStream outputStream = new FileOutputStream(file);
         outputStream.close();
         return outputStream;
+    }
+
+    private Writer createThrowingWriter() {
+        return new Writer() {
+
+            @Override
+            public void write(@NotNull char[] cbuf, int off, int len) throws IOException {
+                throw new IOException("This is meant to happen");
+            }
+
+            @Override
+            public void flush() throws IOException {
+                throw new IOException("This is meant to happen");
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException("This is meant to happen");
+            }
+        };
     }
 
 }

--- a/src/test/java/dev/stalla/PodcastRssWriterInteropTest.java
+++ b/src/test/java/dev/stalla/PodcastRssWriterInteropTest.java
@@ -107,19 +107,22 @@ public class PodcastRssWriterInteropTest {
         );
     }
 
-    private File toUnwritableFile(File file) {
+    @NotNull
+    private File toUnwritableFile(@NotNull File file) {
         // File gives I/O error on writing when it is read-only
         file.setReadOnly();
         return file;
     }
 
-    private OutputStream toUnwritableOutputStream(File file) throws IOException {
+    @NotNull
+    private OutputStream toUnwritableOutputStream(@NotNull File file) throws IOException {
         // OutputStream gives I/O error when it is closed
         final OutputStream outputStream = new FileOutputStream(file);
         outputStream.close();
         return outputStream;
     }
 
+    @NotNull
     private Writer createThrowingWriter() {
         return new Writer() {
 

--- a/src/test/kotlin/dev/stalla/PodcastRssWriterTest.kt
+++ b/src/test/kotlin/dev/stalla/PodcastRssWriterTest.kt
@@ -27,4 +27,40 @@ internal class PodcastRssWriterTest {
             file.delete()
         }
     }
+
+    @Test
+    internal fun `should write a feed to an outputStream correctly`() {
+        val file = File.createTempFile("stalla_test", "writer_output")
+
+        val podcast = aPodcast()
+        file.outputStream().use { PodcastRssWriter.write(podcast, it) }
+
+        assertAll {
+            assertThat(file, "written file").exists()
+            assertThat(file, "written file").isNotEmpty()
+
+            val reparsedPodcast = PodcastRssParser.parse(file)
+            assertThat(reparsedPodcast, "written file matches original Podcast").isEqualTo(podcast)
+
+            file.delete()
+        }
+    }
+
+    @Test
+    internal fun `should write a feed to a Writer correctly`() {
+        val file = File.createTempFile("stalla_test", "writer_output")
+
+        val podcast = aPodcast()
+        file.bufferedWriter().use { PodcastRssWriter.write(podcast, it) }
+
+        assertAll {
+            assertThat(file, "written file").exists()
+            assertThat(file, "written file").isNotEmpty()
+
+            val reparsedPodcast = PodcastRssParser.parse(file)
+            assertThat(reparsedPodcast, "written file matches original Podcast").isEqualTo(podcast)
+
+            file.delete()
+        }
+    }
 }

--- a/src/test/kotlin/dev/stalla/PodcastRssWriterTest.kt
+++ b/src/test/kotlin/dev/stalla/PodcastRssWriterTest.kt
@@ -6,14 +6,14 @@ import assertk.assertions.exists
 import assertk.assertions.isEqualTo
 import dev.stalla.model.aPodcast
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import java.io.File
 
+@ExtendWith(TemporaryFileParameterResolver::class)
 internal class PodcastRssWriterTest {
 
     @Test
-    internal fun `should write a feed to a file correctly`() {
-        val file = File.createTempFile("stalla_test", "writer_output")
-
+    internal fun `should write a feed to a file correctly`(@TemporaryFile file: File) {
         val podcast = aPodcast()
         PodcastRssWriter.write(podcast, file)
 
@@ -23,15 +23,11 @@ internal class PodcastRssWriterTest {
 
             val reparsedPodcast = PodcastRssParser.parse(file)
             assertThat(reparsedPodcast, "written file matches original Podcast").isEqualTo(podcast)
-
-            file.delete()
         }
     }
 
     @Test
-    internal fun `should write a feed to an outputStream correctly`() {
-        val file = File.createTempFile("stalla_test", "writer_output")
-
+    internal fun `should write a feed to an outputStream correctly`(@TemporaryFile file: File) {
         val podcast = aPodcast()
         file.outputStream().use { PodcastRssWriter.write(podcast, it) }
 
@@ -41,15 +37,11 @@ internal class PodcastRssWriterTest {
 
             val reparsedPodcast = PodcastRssParser.parse(file)
             assertThat(reparsedPodcast, "written file matches original Podcast").isEqualTo(podcast)
-
-            file.delete()
         }
     }
 
     @Test
-    internal fun `should write a feed to a Writer correctly`() {
-        val file = File.createTempFile("stalla_test", "writer_output")
-
+    internal fun `should write a feed to a Writer correctly`(@TemporaryFile file: File) {
         val podcast = aPodcast()
         file.bufferedWriter().use { PodcastRssWriter.write(podcast, it) }
 
@@ -59,8 +51,6 @@ internal class PodcastRssWriterTest {
 
             val reparsedPodcast = PodcastRssParser.parse(file)
             assertThat(reparsedPodcast, "written file matches original Podcast").isEqualTo(podcast)
-
-            file.delete()
         }
     }
 }

--- a/src/test/kotlin/dev/stalla/RealLifeFeedsTest.kt
+++ b/src/test/kotlin/dev/stalla/RealLifeFeedsTest.kt
@@ -34,6 +34,6 @@ internal class RealLifeFeedsTest {
     }
 
     companion object {
-        const val resourceFilesPath = "/xml/real-life-feeds"
+        const val resourceFilesPath = "xml/real-life-feeds"
     }
 }

--- a/src/test/kotlin/dev/stalla/TestUtil.kt
+++ b/src/test/kotlin/dev/stalla/TestUtil.kt
@@ -49,12 +49,15 @@ internal fun dateTime(
 
 /** Gets a list of all the resource files in the given resources path */
 internal fun allResourceFilesIn(path: String): List<File> {
-    val files = DomBuilderFactory::class.java.getResourceAsStream(path)!!
-        .bufferedReader()
+    val pathFile = ClassLoader.getSystemResourceAsStream(path)
+        ?: error("Unable to load path: $path")
+
+    val files = pathFile.bufferedReader()
         .readLines()
         .map {
             val testFile = File(path, it)
-            val fileUrl = DomBuilderFactory::class.java.getResource(testFile.path)
+            val fileUrl = ClassLoader.getSystemResource(testFile.path)
+                ?: error("Unable to load test file: ${testFile.path}")
             File(fileUrl.toURI())
         }
 


### PR DESCRIPTION
This PR implements a `Reader`/`Writer` public API for the RSS parser and writer. In addition, the internal delegation chain in `PodcastRssParser#parse` and `PodcastRssWriter#write` have been streamlined — now they all delegate to a "main" implementation, making the other overloads just conveniences on top of that. This simplifies the code and exceptions handling, and ensures consistent behaviour.

On top of that, this PR makes some minor changes to make the tests pass under Windows — for whatever reason it dislikes reading resources the way we were doing before.

Lastly, I now ensure we run Detekt's type-aware `detektMain` task on any run of `:check`. The CI is now set up to run checks on Windows, as well as on Linux, to avoid further issues in the future. I am not adding macOS because we don't really need it for now.

Once this is merged, it'll unblock the #56 PR.