### PR TITLE
Tweak release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         id: gradle
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+          arguments: publishToMavenCentral
         env:
           SONATYPE_USERNAME: mpgirro
           SONATYPE_PASSWORD: ${{secrets.SONATYPE_PASSWORD}}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,7 +227,7 @@ tasks {
         description = "Publishes the the current revision to Maven Central, with pre-flight sanity checks"
 
         doLast {
-            logger.warn("Successfully puclished ${project.group}:${project.name}:${project.version} to Maven Central")
+            logger.warn("Successfully published ${project.group}:${project.name}:${project.version} to Maven Central")
         }
 
         dependsOn(checkVersionBeforeRegistering, named("publishToSonatype"), named("closeAndReleaseSonatypeStagingRepository"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -208,10 +208,28 @@ tasks {
         }
     }
 
-    register("outputVersionDebug") {
-        doLast {
+    val checkVersionBeforeRegistering by registering {
+        group = "publishing"
+        description = "Checks that the version is not set to a SNAPSHOT value before releasing to Maven Central"
+
+        doFirst {
             logger.warn("Project version: ${project.version}")
             logger.warn("GITHUB_REF: ${System.getenv("GITHUB_REF")}")
+
+            if (project.version.toString().endsWith("-SNAPSHOT")) {
+                throw GradleException("Cannot publish a snapshot release to Maven Central")
+            }
         }
+    }
+
+    register("publishToMavenCentral") {
+        group = "publishing"
+        description = "Publishes the the current revision to Maven Central, with pre-flight sanity checks"
+
+        doLast {
+            logger.warn("Successfully puclished ${project.group}:${project.name}:${project.version} to Maven Central")
+        }
+
+        dependsOn(checkVersionBeforeRegistering, named("publishToSonatype"), named("closeAndReleaseSonatypeStagingRepository"))
     }
 }


### PR DESCRIPTION
Given the issue we had publishing 1.0.0 was due to a version name parsing problem, this adds a sanity check on the value before proceeding with the actual publishing.