### PR TITLE
Deprecations for v1.1.0

### DIFF
--- a/api/stalla.api
+++ b/api/stalla.api
@@ -370,6 +370,7 @@ public abstract interface class dev/stalla/builder/podcast/PodcastBuilder : dev/
 	public abstract fun getGoogleplayBuilder ()Ldev/stalla/builder/podcast/PodcastGoogleplayBuilder;
 	public abstract fun getItunesBuilder ()Ldev/stalla/builder/podcast/PodcastItunesBuilder;
 	public abstract fun getPodcastPodcastindexBuilder ()Ldev/stalla/builder/podcast/PodcastPodcastindexBuilder;
+	public abstract fun getPodcastindexBuilder ()Ldev/stalla/builder/podcast/PodcastPodcastindexBuilder;
 	public abstract fun imageBuilder (Ldev/stalla/builder/RssImageBuilder;)Ldev/stalla/builder/podcast/PodcastBuilder;
 	public abstract fun language (Ljava/util/Locale;)Ldev/stalla/builder/podcast/PodcastBuilder;
 	public abstract fun lastBuildDate (Ljava/time/temporal/TemporalAccessor;)Ldev/stalla/builder/podcast/PodcastBuilder;

--- a/api/stalla.api
+++ b/api/stalla.api
@@ -630,6 +630,8 @@ public class dev/stalla/model/MediaType {
 	public fun hashCode ()I
 	public final fun match (Ldev/stalla/model/MediaType;)Z
 	public final fun match (Ljava/lang/String;)Z
+	public final fun matches (Ldev/stalla/model/MediaType;)Z
+	public final fun matches (Ljava/lang/String;)Z
 	public static fun of (Ljava/lang/String;)Ldev/stalla/model/MediaType;
 	public final fun parameter (Ljava/lang/String;)Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
@@ -1419,6 +1421,8 @@ public final class dev/stalla/model/podcastindex/GeographicLocation {
 	public fun hashCode ()I
 	public final fun match (Ldev/stalla/model/podcastindex/GeographicLocation;)Z
 	public final fun match (Ljava/lang/String;)Z
+	public final fun matches (Ldev/stalla/model/podcastindex/GeographicLocation;)Z
+	public final fun matches (Ljava/lang/String;)Z
 	public static fun of (Ljava/lang/String;)Ldev/stalla/model/podcastindex/GeographicLocation;
 	public final fun parameter (Ljava/lang/String;)Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;

--- a/api/stalla.api
+++ b/api/stalla.api
@@ -1419,8 +1419,6 @@ public final class dev/stalla/model/podcastindex/GeographicLocation {
 	public final fun getParameters ()Ljava/util/List;
 	public final fun getUncertainty ()Ljava/lang/Double;
 	public fun hashCode ()I
-	public final fun match (Ldev/stalla/model/podcastindex/GeographicLocation;)Z
-	public final fun match (Ljava/lang/String;)Z
 	public final fun matches (Ldev/stalla/model/podcastindex/GeographicLocation;)Z
 	public final fun matches (Ljava/lang/String;)Z
 	public static fun of (Ljava/lang/String;)Ldev/stalla/model/podcastindex/GeographicLocation;

--- a/src/main/kotlin/dev/stalla/builder/episode/EpisodeBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/episode/EpisodeBuilder.kt
@@ -35,7 +35,7 @@ public interface EpisodeBuilder : Builder<Episode> {
     /** The builder for data from the Bitlove namespace. */
     public val bitloveBuilder: EpisodeBitloveBuilder
 
-    /** The builder for data from the Podcast namespace. */
+    /** The builder for data from the Podcastindex namespace. */
     public val podcastindexBuilder: EpisodePodcastindexBuilder
 
     /** Set the title value. */

--- a/src/main/kotlin/dev/stalla/builder/podcast/PodcastBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/podcast/PodcastBuilder.kt
@@ -34,7 +34,14 @@ public interface PodcastBuilder : Builder<Podcast> {
     /** The builder for data from the Google Play namespace. */
     public val googleplayBuilder: PodcastGoogleplayBuilder
 
-    /** Set the Podcast namespace builder. */
+    /** The builder for data from the Podcastindex namespace. */
+    public val podcastindexBuilder: PodcastPodcastindexBuilder
+
+    /** The builder for data from the Podcastindex namespace. */
+    @Deprecated(
+        message = "This property is scheduled for removal in v2.0.0",
+        replaceWith = ReplaceWith("podcastindexBuilder")
+    )
     public val podcastPodcastindexBuilder: PodcastPodcastindexBuilder
 
     /** Set the title value. */
@@ -97,7 +104,7 @@ public interface PodcastBuilder : Builder<Podcast> {
             fyydBuilder.applyFrom(podcast.fyyd)
             feedpressBuilder.applyFrom(podcast.feedpress)
             googleplayBuilder.applyFrom(podcast.googleplay)
-            podcastPodcastindexBuilder.applyFrom(podcast.podcastindex)
+            podcastindexBuilder.applyFrom(podcast.podcastindex)
             title(podcast.title)
             link(podcast.link)
             description(podcast.description)

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastBuilder.kt
@@ -64,7 +64,9 @@ internal class ValidatingPodcastBuilder : ProvidingPodcastBuilder {
 
     override val googleplayBuilder: PodcastGoogleplayBuilder = ValidatingPodcastGoogleplayBuilder()
 
-    override val podcastPodcastindexBuilder: PodcastPodcastindexBuilder = ValidatingPodcastPodcastindexBuilder()
+    override val podcastindexBuilder: PodcastPodcastindexBuilder = ValidatingPodcastPodcastindexBuilder()
+
+    override val podcastPodcastindexBuilder: PodcastPodcastindexBuilder by this::podcastindexBuilder
 
     override fun title(title: String): PodcastBuilder = apply { this.titleValue = title }
 
@@ -156,7 +158,7 @@ internal class ValidatingPodcastBuilder : ProvidingPodcastBuilder {
             feedpress = feedpressBuilder.build(),
             googleplay = googleplayBuilder.build(),
             categories = categoryBuilders.mapNotNull { it.build() }.asUnmodifiable(),
-            podcastindex = podcastPodcastindexBuilder.build()
+            podcastindex = podcastindexBuilder.build()
         )
     }
 }

--- a/src/main/kotlin/dev/stalla/model/MediaType.kt
+++ b/src/main/kotlin/dev/stalla/model/MediaType.kt
@@ -90,7 +90,7 @@ public open class MediaType private constructor(
     /**
      * Checks if `this` type matches a [pattern] type taking into account placeholder symbols `*` and parameters.
      */
-    public fun match(pattern: MediaType?): Boolean {
+    public fun matches(pattern: MediaType?): Boolean {
         contract {
             returns(true) implies (pattern != null)
         }
@@ -109,7 +109,26 @@ public open class MediaType private constructor(
      * Checks if `this` type matches a [pattern] type taking
      * into account placeholder symbols `*` and parameters.
      */
-    public fun match(pattern: String): Boolean = match(of(pattern))
+    public fun matches(pattern: String): Boolean = matches(of(pattern))
+
+    /**
+     * Checks if `this` type matches a [pattern] type taking into account placeholder symbols `*` and parameters.
+     */
+    @Deprecated(
+        message = "This method is scheduled for removal in v2.0.0",
+        replaceWith = ReplaceWith("matches")
+    )
+    public fun match(pattern: MediaType?): Boolean = matches(pattern)
+
+    /**
+     * Checks if `this` type matches a [pattern] type taking
+     * into account placeholder symbols `*` and parameters.
+     */
+    @Deprecated(
+        message = "This method is scheduled for removal in v2.0.0",
+        replaceWith = ReplaceWith("matches")
+    )
+    public fun match(pattern: String): Boolean = matches(pattern)
 
     private fun match(parameters1: List<Parameter>, parameters2: List<Parameter>): Boolean {
         for ((patternName, patternValue) in parameters1) {

--- a/src/main/kotlin/dev/stalla/model/MediaType.kt
+++ b/src/main/kotlin/dev/stalla/model/MediaType.kt
@@ -89,6 +89,7 @@ public open class MediaType private constructor(
 
     /**
      * Checks if `this` type matches a [pattern] type taking into account placeholder symbols `*` and parameters.
+     * @since 1.1.0
      */
     public fun matches(pattern: MediaType?): Boolean {
         contract {
@@ -108,6 +109,7 @@ public open class MediaType private constructor(
     /**
      * Checks if `this` type matches a [pattern] type taking
      * into account placeholder symbols `*` and parameters.
+     * @since 1.1.0
      */
     public fun matches(pattern: String): Boolean = matches(of(pattern))
 

--- a/src/main/kotlin/dev/stalla/model/podcastindex/GeographicLocation.kt
+++ b/src/main/kotlin/dev/stalla/model/podcastindex/GeographicLocation.kt
@@ -134,20 +134,6 @@ public class GeographicLocation public constructor(
     /** Checks if `this` type matches a [pattern] type taking parameters into account. */
     public fun matches(pattern: String): Boolean = matches(of(pattern))
 
-    /** Checks if `this` type matches a [pattern] type taking parameters into account. */
-    @Deprecated(
-        message = "This method is scheduled for removal in v2.0.0",
-        replaceWith = ReplaceWith("matches")
-    )
-    public fun match(pattern: GeographicLocation?): Boolean = matches(pattern)
-
-    /** Checks if `this` type matches a [pattern] type taking parameters into account. */
-    @Deprecated(
-        message = "This method is scheduled for removal in v2.0.0",
-        replaceWith = ReplaceWith("matches")
-    )
-    public fun match(pattern: String): Boolean = matches(pattern)
-
     private fun match(parameters1: List<Parameter>, parameters2: List<Parameter>): Boolean {
         for (param1 in parameters1) {
             val value2 = parameter(param1.key, parameters2)

--- a/src/main/kotlin/dev/stalla/model/podcastindex/GeographicLocation.kt
+++ b/src/main/kotlin/dev/stalla/model/podcastindex/GeographicLocation.kt
@@ -111,7 +111,7 @@ public class GeographicLocation public constructor(
     public fun withoutParameters(): GeographicLocation = GeographicLocation(latitude, longitude, altitude)
 
     /** Checks if `this` type matches a [pattern] type taking parameters into account. */
-    public fun match(pattern: GeographicLocation?): Boolean {
+    public fun matches(pattern: GeographicLocation?): Boolean {
         contract {
             returns(true) implies (pattern != null)
         }
@@ -132,7 +132,21 @@ public class GeographicLocation public constructor(
     }
 
     /** Checks if `this` type matches a [pattern] type taking parameters into account. */
-    public fun match(pattern: String): Boolean = match(of(pattern))
+    public fun matches(pattern: String): Boolean = matches(of(pattern))
+
+    /** Checks if `this` type matches a [pattern] type taking parameters into account. */
+    @Deprecated(
+        message = "This method is scheduled for removal in v2.0.0",
+        replaceWith = ReplaceWith("matches")
+    )
+    public fun match(pattern: GeographicLocation?): Boolean = matches(pattern)
+
+    /** Checks if `this` type matches a [pattern] type taking parameters into account. */
+    @Deprecated(
+        message = "This method is scheduled for removal in v2.0.0",
+        replaceWith = ReplaceWith("matches")
+    )
+    public fun match(pattern: String): Boolean = matches(pattern)
 
     private fun match(parameters1: List<Parameter>, parameters2: List<Parameter>): Boolean {
         for (param1 in parameters1) {

--- a/src/main/kotlin/dev/stalla/parser/namespace/PodcastindexParser.kt
+++ b/src/main/kotlin/dev/stalla/parser/namespace/PodcastindexParser.kt
@@ -46,25 +46,25 @@ internal object PodcastindexParser : NamespaceParser() {
                 val lockedBuilder = ifCanBeParsed {
                     toLockedBuilder(builder.createLockedBuilder())
                 } ?: return
-                builder.podcastPodcastindexBuilder.lockedBuilder(lockedBuilder)
+                builder.podcastindexBuilder.lockedBuilder(lockedBuilder)
             }
             "funding" -> {
                 val fundingBuilder = ifCanBeParsed {
                     toFundingBuilder(builder.createFundingBuilder())
                 } ?: return
-                builder.podcastPodcastindexBuilder.addFundingBuilder(fundingBuilder)
+                builder.podcastindexBuilder.addFundingBuilder(fundingBuilder)
             }
             "person" -> {
                 val personBuilder = ifCanBeParsed {
                     toPersonBuilder(builder.createPersonBuilder())
                 } ?: return
-                builder.podcastPodcastindexBuilder.addPersonBuilder(personBuilder)
+                builder.podcastindexBuilder.addPersonBuilder(personBuilder)
             }
             "location" -> {
                 val locationBuilder = ifCanBeParsed {
                     toLocationBuilder(builder.createLocationBuilder())
                 } ?: return
-                builder.podcastPodcastindexBuilder.locationBuilder(locationBuilder)
+                builder.podcastindexBuilder.locationBuilder(locationBuilder)
             }
             else -> pass
         }

--- a/src/test/kotlin/dev/stalla/Assertions.kt
+++ b/src/test/kotlin/dev/stalla/Assertions.kt
@@ -158,7 +158,7 @@ internal fun Assert<MediaType>.equalToString(expected: String) = given { mediaTy
 
 /** Asserts that [MediaType.toString] matches the expected value. */
 internal fun Assert<MediaType>.equalToString(expected: MediaType) = given { mediaType ->
-    if (mediaType.match(expected)) return@given
+    if (mediaType.matches(expected)) return@given
     expected(
         "to be: '$expected' but was: '$mediaType'",
         expected = expected,
@@ -166,9 +166,9 @@ internal fun Assert<MediaType>.equalToString(expected: MediaType) = given { medi
     )
 }
 
-/** Asserts that [MediaType.match] matches the expected value. */
+/** Asserts that [MediaType.matches] matches the expected value. */
 internal fun Assert<MediaType>.matchPattern(expected: String) = given { mediaType ->
-    if (mediaType.match(expected)) return@given
+    if (mediaType.matches(expected)) return@given
     expected(
         "to have the string form: '$expected' but was: '$mediaType'",
         expected = expected,
@@ -176,9 +176,9 @@ internal fun Assert<MediaType>.matchPattern(expected: String) = given { mediaTyp
     )
 }
 
-/** Asserts that [MediaType.match] matches the expected value. */
+/** Asserts that [MediaType.matches] matches the expected value. */
 internal fun Assert<MediaType>.matchPattern(expected: MediaType) = given { mediaType ->
-    if (mediaType.match(expected)) return@given
+    if (mediaType.matches(expected)) return@given
     expected(
         "to be: '$expected' but was: '$mediaType'",
         expected = expected,
@@ -186,16 +186,16 @@ internal fun Assert<MediaType>.matchPattern(expected: MediaType) = given { media
     )
 }
 
-/** Asserts that this matches [expected] symmetrically using [MediaType.match]. */
+/** Asserts that this matches [expected] symmetrically using [MediaType.matches]. */
 internal fun Assert<MediaType>.matchesSymmetrically(expected: MediaType?) = given { mediaType ->
-    if (!mediaType.match(expected)) {
+    if (!mediaType.matches(expected)) {
         expected(
             "to match symmetrically, but the direction: '$mediaType' match '$expected' failed",
             expected = true,
             actual = false
         )
     }
-    if (!expected.match(mediaType)) {
+    if (!expected.matches(mediaType)) {
         expected(
             "to match symmetrically, but the direction: '$expected' match '$mediaType' failed",
             expected = true,
@@ -204,16 +204,16 @@ internal fun Assert<MediaType>.matchesSymmetrically(expected: MediaType?) = give
     }
 }
 
-/** Asserts that this does not match [expected] symmetrically using [MediaType.match]. */
+/** Asserts that this does not match [expected] symmetrically using [MediaType.matches]. */
 internal fun Assert<MediaType>.doesNotMatchSymmetrically(expected: MediaType?) = given { mediaType ->
-    if (mediaType.match(expected)) {
+    if (mediaType.matches(expected)) {
         expected(
             "to not match symmetrically, but the direction: '$mediaType' match '$expected' succeeded",
             expected = false,
             actual = true
         )
     }
-    if (expected != null && expected.match(mediaType)) {
+    if (expected != null && expected.matches(mediaType)) {
         expected(
             "to not match symmetrically, but the direction: '$expected' match '$mediaType' succeeded",
             expected = false,
@@ -222,9 +222,9 @@ internal fun Assert<MediaType>.doesNotMatchSymmetrically(expected: MediaType?) =
     }
 }
 
-/** Asserts that [GeographicLocation.match] matches the expected value. */
+/** Asserts that [GeographicLocation.matches] matches the expected value. */
 internal fun Assert<GeographicLocation>.matchPattern(expected: GeographicLocation) = given { geoLocation ->
-    if (geoLocation.match(expected)) return@given
+    if (geoLocation.matches(expected)) return@given
     expected(
         "to be: '$expected', but was: '$geoLocation'",
         expected = expected,

--- a/src/test/kotlin/dev/stalla/builder/fake/podcast/FakePodcastBuilder.kt
+++ b/src/test/kotlin/dev/stalla/builder/fake/podcast/FakePodcastBuilder.kt
@@ -172,12 +172,11 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), ProvidingPodcastBuil
         return result
     }
 
-    override fun toString(): String {
-        return "FakePodcastBuilder(titleValue=$titleValue, linkValue=$linkValue, descriptionValue=$descriptionValue, " +
+    override fun toString(): String =
+        "FakePodcastBuilder(titleValue=$titleValue, linkValue=$linkValue, descriptionValue=$descriptionValue, " +
             "languageValue=$languageValue, pubDate=$pubDate, lastBuildDate=$lastBuildDate, generator=$generator, copyright=$copyright, " +
             "docs=$docs, managingEditor=$managingEditor, webMaster=$webMaster, ttl=$ttl, imageBuilder=$imageBuilder, " +
             "episodeBuilders=$episodeBuilders, categoryBuilders=$categoryBuilders, itunesBuilder=$itunesBuilder, atomBuilder=$atomBuilder, " +
             "fyydBuilder=$fyydBuilder, feedpressBuilder=$feedpressBuilder, googleplayBuilder=$googleplayBuilder, " +
             "podcastindexBuilder=$podcastindexBuilder, podcastPodcastindexBuilder=$podcastPodcastindexBuilder)"
-    }
 }

--- a/src/test/kotlin/dev/stalla/builder/fake/podcast/FakePodcastBuilder.kt
+++ b/src/test/kotlin/dev/stalla/builder/fake/podcast/FakePodcastBuilder.kt
@@ -56,7 +56,9 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), ProvidingPodcastBuil
 
     override val googleplayBuilder: FakePodcastGoogleplayBuilder = FakePodcastGoogleplayBuilder()
 
-    override val podcastPodcastindexBuilder: FakePodcastPodcastindexBuilder = FakePodcastPodcastindexBuilder()
+    override val podcastindexBuilder: FakePodcastPodcastindexBuilder = FakePodcastPodcastindexBuilder()
+
+    override val podcastPodcastindexBuilder: FakePodcastPodcastindexBuilder by this::podcastindexBuilder
 
     override fun title(title: String): PodcastBuilder = apply { this.titleValue = title }
 
@@ -114,7 +116,9 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), ProvidingPodcastBuil
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is FakePodcastBuilder) return false
+        if (javaClass != other?.javaClass) return false
+
+        other as FakePodcastBuilder
 
         if (titleValue != other.titleValue) return false
         if (linkValue != other.linkValue) return false
@@ -136,6 +140,7 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), ProvidingPodcastBuil
         if (fyydBuilder != other.fyydBuilder) return false
         if (feedpressBuilder != other.feedpressBuilder) return false
         if (googleplayBuilder != other.googleplayBuilder) return false
+        if (podcastindexBuilder != other.podcastindexBuilder) return false
         if (podcastPodcastindexBuilder != other.podcastPodcastindexBuilder) return false
 
         return true
@@ -153,7 +158,7 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), ProvidingPodcastBuil
         result = 31 * result + (docs?.hashCode() ?: 0)
         result = 31 * result + (managingEditor?.hashCode() ?: 0)
         result = 31 * result + (webMaster?.hashCode() ?: 0)
-        result = 31 * result + (ttl?.hashCode() ?: 0)
+        result = 31 * result + (ttl ?: 0)
         result = 31 * result + (imageBuilder?.hashCode() ?: 0)
         result = 31 * result + episodeBuilders.hashCode()
         result = 31 * result + categoryBuilders.hashCode()
@@ -162,14 +167,17 @@ internal class FakePodcastBuilder : FakeBuilder<Podcast>(), ProvidingPodcastBuil
         result = 31 * result + fyydBuilder.hashCode()
         result = 31 * result + feedpressBuilder.hashCode()
         result = 31 * result + googleplayBuilder.hashCode()
+        result = 31 * result + podcastindexBuilder.hashCode()
         result = 31 * result + podcastPodcastindexBuilder.hashCode()
         return result
     }
 
-    override fun toString() =
-        "FakePodcastBuilder(titleValue=$titleValue, linkValue=$linkValue, descriptionValue=$descriptionValue, languageValue=$languageValue, " +
-            "pubDate=$pubDate, lastBuildDate=$lastBuildDate, generator=$generator, copyright=$copyright, docs=$docs, " +
-            "managingEditor=$managingEditor, webMaster=$webMaster, ttl=$ttl, imageBuilder=$imageBuilder, episodeBuilders=$episodeBuilders, " +
-            "categoryBuilders=$categoryBuilders, iTunesBuilder=$itunesBuilder, atomBuilder=$atomBuilder, fyydBuilder=$fyydBuilder, " +
-            "feedpressBuilder=$feedpressBuilder, googlePlayBuilder=$googleplayBuilder, podcastBuilder=$podcastPodcastindexBuilder)"
+    override fun toString(): String {
+        return "FakePodcastBuilder(titleValue=$titleValue, linkValue=$linkValue, descriptionValue=$descriptionValue, " +
+            "languageValue=$languageValue, pubDate=$pubDate, lastBuildDate=$lastBuildDate, generator=$generator, copyright=$copyright, " +
+            "docs=$docs, managingEditor=$managingEditor, webMaster=$webMaster, ttl=$ttl, imageBuilder=$imageBuilder, " +
+            "episodeBuilders=$episodeBuilders, categoryBuilders=$categoryBuilders, itunesBuilder=$itunesBuilder, atomBuilder=$atomBuilder, " +
+            "fyydBuilder=$fyydBuilder, feedpressBuilder=$feedpressBuilder, googleplayBuilder=$googleplayBuilder, " +
+            "podcastindexBuilder=$podcastindexBuilder, podcastPodcastindexBuilder=$podcastPodcastindexBuilder)"
+    }
 }

--- a/src/test/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
+++ b/src/test/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastBuilderTest.kt
@@ -215,7 +215,7 @@ internal class ValidatingPodcastBuilderTest {
                 feedpressBuilder.newsletterId("feedpress newsletterId")
                 fyydBuilder.verify("fyyd verify")
                 googleplayBuilder.description("play description")
-                podcastPodcastindexBuilder.lockedBuilder(expectedLockedBuilder)
+                podcastindexBuilder.lockedBuilder(expectedLockedBuilder)
             }
 
         assertAll {

--- a/src/test/kotlin/dev/stalla/model/MediaTypeTest.kt
+++ b/src/test/kotlin/dev/stalla/model/MediaTypeTest.kt
@@ -235,12 +235,12 @@ internal class MediaTypeTest {
 
     @Test
     fun `should match a predefined instance from a string pattern`() {
-        assertThat(MediaType.AAC_AUDIO.match("audio/aac")).isTrue()
+        assertThat(MediaType.AAC_AUDIO.matches("audio/aac")).isTrue()
     }
 
     @Test
     fun `should match a predefined instance with a wildcard subtype`() {
-        assertThat(MediaType.AAC_AUDIO.match("audio/*")).isTrue()
+        assertThat(MediaType.AAC_AUDIO.matches("audio/*")).isTrue()
     }
 
     @Test

--- a/src/test/kotlin/dev/stalla/model/podcastindex/GeographicLocationTest.kt
+++ b/src/test/kotlin/dev/stalla/model/podcastindex/GeographicLocationTest.kt
@@ -164,76 +164,76 @@ class GeographicLocationTest {
     fun `should match Geo URIs when WGS-84 special pole case applies correctly`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:90,-22.43;crs=WGS84"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:90,46;crs=WGS84"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should not match Geo URIs in WGS-84 special pole case if the latitude is different`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:90,10"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:45,20"))
-        assertThat(geoLocation1.match(geoLocation2)).isFalse()
+        assertThat(geoLocation1.matches(geoLocation2)).isFalse()
     }
 
     @Test
     fun `should no match Geo URIs in WGS-84 special pole case if the latitude has a different sign`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:90,10"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:-90,10"))
-        assertThat(geoLocation1.match(geoLocation2)).isFalse()
+        assertThat(geoLocation1.matches(geoLocation2)).isFalse()
     }
 
     @Test
     fun `should match Geo URIs in WGS-84 special pole case by ignoring the longitude`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:90,5"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:90,10"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should interprete a missing CRS value as WGS-84 when matching two Geo URIs with WGS-84 special pole case`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:90,5"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:90,10;crs=WGS84"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should match Geo URIs in WGS-84 special date line case if the longitude has a different sign`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:10,180"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:10,-180"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should interprete a missing CRS value as WGS-84 when matching two Geo URIs with WGS-84 special date line case`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:10,180"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:10,-180;crs=WGS84"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should match Geo URIs parameters bitwise identical after percent-decoding parameter names are case insensitive`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:66,30;u=6.500;FOo=this%2dthat"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:66.0,30;u=6.5;foo=this-that"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should match Geo URIs with parameter order being insignificant`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:47,11;foo=blue;bar=white"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:47,11;bar=white;foo=blue"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should match Geo URIs with parameter keys being case-insensitive`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:22,0;bar=blue"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:22,0;BAR=blue"))
-        assertThat(geoLocation1.match(geoLocation2)).isTrue()
+        assertThat(geoLocation1.matches(geoLocation2)).isTrue()
     }
 
     @Test
     fun `should not match Geo URIs with parameter values being case-sensitive`() {
         val geoLocation1 = checkNotNull(GeographicLocation.of("geo:22,0;bar=BLUE"))
         val geoLocation2 = checkNotNull(GeographicLocation.of("geo:22,0;bar=blue"))
-        assertThat(geoLocation1.match(geoLocation2)).isFalse()
+        assertThat(geoLocation1.matches(geoLocation2)).isFalse()
     }
 }

--- a/src/test/kotlin/dev/stalla/parser/namespace/PodcastindexParserTest.kt
+++ b/src/test/kotlin/dev/stalla/parser/namespace/PodcastindexParserTest.kt
@@ -97,7 +97,7 @@ internal class PodcastindexParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.podcastPodcastindexBuilder, "channel.podcastindex").isNotNull().all {
+        assertThat(builder.podcastindexBuilder, "channel.podcastindex").isNotNull().all {
             prop(FakePodcastPodcastindexBuilder::lockedBuilderValue).isEqualTo(expectedLockedBuilder)
             prop(FakePodcastPodcastindexBuilder::fundingBuilders).containsExactly(expectedFundingBuilder)
             prop(FakePodcastPodcastindexBuilder::personBuilders).containsExactly(expectedPodcastPersonBuilder)
@@ -111,7 +111,7 @@ internal class PodcastindexParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.podcastPodcastindexBuilder, "channel.podcastindex").all {
+        assertThat(builder.podcastindexBuilder, "channel.podcastindex").all {
             prop(FakePodcastPodcastindexBuilder::lockedBuilderValue).isNull()
             prop(FakePodcastPodcastindexBuilder::fundingBuilders).isEmpty()
             prop(FakePodcastPodcastindexBuilder::personBuilders).isEmpty()
@@ -125,7 +125,7 @@ internal class PodcastindexParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.podcastPodcastindexBuilder, "channel.podcastindex").all {
+        assertThat(builder.podcastindexBuilder, "channel.podcastindex").all {
             prop(FakePodcastPodcastindexBuilder::lockedBuilderValue).isNull()
             prop(FakePodcastPodcastindexBuilder::fundingBuilders).isEmpty()
             prop(FakePodcastPodcastindexBuilder::personBuilders).isEmpty()
@@ -191,7 +191,7 @@ internal class PodcastindexParserTest : NamespaceParserTest() {
         val builder = FakePodcastBuilder()
         channel.parseChannelChildNodes(builder)
 
-        assertThat(builder.podcastPodcastindexBuilder, "channel.podcastindex").all {
+        assertThat(builder.podcastindexBuilder, "channel.podcastindex").all {
             prop(FakePodcastPodcastindexBuilder::lockedBuilderValue).isNull()
         }
     }


### PR DESCRIPTION
This PR deprecates the `podcastPodcastindexBuilder` member exposed in the `PodcastBuilder` interface, and introduces `podcastindexBuilder` as the replacement. This closes #89.

As discussed in #90, it also deprecates the `match` method in `MediaType` and `GeographicLocation` in favour of `matches`.