### PR TITLE
Fix all the `asBuilders()` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # CHANGELOG
 
-## v1.1.0 (under development)
+## v1.1.0
 
-* Add support for PodcastIndex namespace phase 2 tags
-* Some APIs have been renamed and their old version has been deprecated (see API changes table below)
+* Add support for PodcastIndex namespace
+  [phase 2 tags](https://github.com/Podcastindex-org/podcast-namespace/blob/4b7e66f/README.md#phase-2-closed-on-13121)
+* Fix a major bug: the `asBuilders()` extension functions were returning lists with a single builder repeated, instead of a distinct builder per item
+  of the source list
+* Builders implement `equals()`, `hashCode()` and `toString()`
+* Some APIs have been renamed, and their old version has been deprecated (see API changes table below)
 
 ### Notable API changes
 
@@ -30,7 +34,7 @@ API that has changed | What has changed | Notes
 * Adds feed writing support
 * Adds additional elements for RSS and iTunes namespace
 * Adds support for Podcastindex namespace
-* Adds a huge amount of unit tests
+* Adds a huge number of unit tests
 * Adds builder factory methods to model companion objects
 * Changes to java.time representation
 
@@ -53,7 +57,8 @@ API that has changed | What has changed | Notes
 ## v0.5.1
 
 * Fixes the URI for the Podlove Simple Chapter namespace.
-* Adds [Travis-CI](https://travis-ci.org/mpgirro/wien), [Codacy](https://app.codacy.com/project/mpgirro/wien), and [CodeCov](https://codecov.io/gh/mpgirro/wien) setup.
+* Adds [Travis-CI](https://travis-ci.org/mpgirro/wien), [Codacy](https://app.codacy.com/project/mpgirro/wien),
+  and [CodeCov](https://codecov.io/gh/mpgirro/wien) setup.
 
 ## v0.5.0
 

--- a/src/main/kotlin/dev/stalla/builder/validating/ValidatingAtomBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/ValidatingAtomBuilder.kt
@@ -37,4 +37,25 @@ internal class ValidatingAtomBuilder : AtomBuilder {
             links = linkBuilders.mapNotNull { it.build() }.asUnmodifiable()
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingAtomBuilder) return false
+
+        if (authorBuilders != other.authorBuilders) return false
+        if (contributorBuilders != other.contributorBuilders) return false
+        if (linkBuilders != other.linkBuilders) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = authorBuilders.hashCode()
+        result = 31 * result + contributorBuilders.hashCode()
+        result = 31 * result + linkBuilders.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingAtomBuilder(authorBuilders=$authorBuilders, contributorBuilders=$contributorBuilders, linkBuilders=$linkBuilders)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/ValidatingAtomPersonBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/ValidatingAtomPersonBuilder.kt
@@ -7,19 +7,19 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingAtomPersonBuilder : AtomPersonBuilder {
 
-    private lateinit var nameValue: String
+    private var name: String? = null
 
     private var email: String? = null
     private var uri: String? = null
 
-    override fun name(name: String): AtomPersonBuilder = apply { this.nameValue = name }
+    override fun name(name: String): AtomPersonBuilder = apply { this.name = name }
 
     override fun email(email: String?): AtomPersonBuilder = apply { this.email = email }
 
     override fun uri(uri: String?): AtomPersonBuilder = apply { this.uri = uri }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::nameValue.isInitialized
+        get() = name != null
 
     override fun build(): AtomPerson? {
         if (!hasEnoughDataToBuild) {
@@ -27,9 +27,29 @@ internal class ValidatingAtomPersonBuilder : AtomPersonBuilder {
         }
 
         return AtomPerson(
-            name = nameValue,
+            name = checkRequiredProperty(::name),
             email = email,
             uri = uri
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingAtomPersonBuilder) return false
+
+        if (name != other.name) return false
+        if (email != other.email) return false
+        if (uri != other.uri) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + (email?.hashCode() ?: 0)
+        result = 31 * result + (uri?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String = "ValidatingAtomPersonBuilder(name='$name', email=$email, uri=$uri)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/ValidatingHrefOnlyImageBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/ValidatingHrefOnlyImageBuilder.kt
@@ -7,18 +7,31 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingHrefOnlyImageBuilder : HrefOnlyImageBuilder {
 
-    private lateinit var hrefValue: String
+    private var href: String? = null
 
-    override fun href(href: String): HrefOnlyImageBuilder = apply { this.hrefValue = href }
+    override fun href(href: String): HrefOnlyImageBuilder = apply { this.href = href }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::hrefValue.isInitialized
+        get() = href != null
 
     override fun build(): HrefOnlyImage? {
         if (!hasEnoughDataToBuild) {
             return null
         }
 
-        return HrefOnlyImage(href = hrefValue)
+        return HrefOnlyImage(href = checkRequiredProperty(::href))
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingHrefOnlyImageBuilder) return false
+
+        if (href != other.href) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = href.hashCode()
+
+    override fun toString(): String = "ValidatingHrefOnlyImageBuilder(href='$href')"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/ValidatingLinkBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/ValidatingLinkBuilder.kt
@@ -8,7 +8,7 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingLinkBuilder : LinkBuilder {
 
-    private lateinit var hrefValue: String
+    private var href: String? = null
 
     private var hrefLang: String? = null
     private var hrefResolved: String? = null
@@ -17,7 +17,7 @@ internal class ValidatingLinkBuilder : LinkBuilder {
     private var title: String? = null
     private var type: MediaType? = null
 
-    override fun href(href: String): LinkBuilder = apply { this.hrefValue = href }
+    override fun href(href: String): LinkBuilder = apply { this.href = href }
 
     override fun hrefLang(hrefLang: String?): LinkBuilder = apply { this.hrefLang = hrefLang }
 
@@ -32,7 +32,7 @@ internal class ValidatingLinkBuilder : LinkBuilder {
     override fun type(type: MediaType?): LinkBuilder = apply { this.type = type }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::hrefValue.isInitialized
+        get() = href != null
 
     override fun build(): Link? {
         if (!hasEnoughDataToBuild) {
@@ -40,7 +40,7 @@ internal class ValidatingLinkBuilder : LinkBuilder {
         }
 
         return Link(
-            href = hrefValue,
+            href = checkRequiredProperty(::href),
             hrefLang = hrefLang,
             hrefResolved = hrefResolved,
             length = length,
@@ -49,4 +49,34 @@ internal class ValidatingLinkBuilder : LinkBuilder {
             type = type
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingLinkBuilder) return false
+
+        if (href != other.href) return false
+        if (hrefLang != other.hrefLang) return false
+        if (hrefResolved != other.hrefResolved) return false
+        if (length != other.length) return false
+        if (rel != other.rel) return false
+        if (title != other.title) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = href.hashCode()
+        result = 31 * result + (hrefLang?.hashCode() ?: 0)
+        result = 31 * result + (hrefResolved?.hashCode() ?: 0)
+        result = 31 * result + (length?.hashCode() ?: 0)
+        result = 31 * result + (rel?.hashCode() ?: 0)
+        result = 31 * result + (title?.hashCode() ?: 0)
+        result = 31 * result + (type?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingLinkBuilder(href='$href', hrefLang=$hrefLang, hrefResolved=$hrefResolved, length=$length, rel=$rel, title=$title, " +
+            "type=$type)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/ValidatingRssCategoryBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/ValidatingRssCategoryBuilder.kt
@@ -7,16 +7,16 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingRssCategoryBuilder : RssCategoryBuilder {
 
-    private lateinit var categoryValue: String
+    private var category: String? = null
 
     private var domain: String? = null
 
-    override fun category(category: String): RssCategoryBuilder = apply { this.categoryValue = category }
+    override fun category(category: String): RssCategoryBuilder = apply { this.category = category }
 
     override fun domain(domain: String?): RssCategoryBuilder = apply { this.domain = domain }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::categoryValue.isInitialized
+        get() = category != null
 
     override fun build(): RssCategory? {
         if (!hasEnoughDataToBuild) {
@@ -24,8 +24,26 @@ internal class ValidatingRssCategoryBuilder : RssCategoryBuilder {
         }
 
         return RssCategory(
-            name = categoryValue,
+            name = checkRequiredProperty(::category, "category name is missing"),
             domain = domain
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingRssCategoryBuilder) return false
+
+        if (category != other.category) return false
+        if (domain != other.domain) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = category.hashCode()
+        result = 31 * result + (domain?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String = "ValidatingRssCategoryBuilder(category='$category', domain=$domain)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/ValidatingRssImageBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/ValidatingRssImageBuilder.kt
@@ -7,19 +7,19 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingRssImageBuilder : RssImageBuilder {
 
-    private lateinit var urlValue: String
-    private lateinit var titleValue: String
-    private lateinit var linkValue: String
+    private var url: String? = null
+    private var title: String? = null
+    private var link: String? = null
 
     private var width: Int? = null
     private var height: Int? = null
     private var description: String? = null
 
-    override fun url(url: String): RssImageBuilder = apply { this.urlValue = url }
+    override fun url(url: String): RssImageBuilder = apply { this.url = url }
 
-    override fun title(title: String): RssImageBuilder = apply { this.titleValue = title }
+    override fun title(title: String): RssImageBuilder = apply { this.title = title }
 
-    override fun link(link: String): RssImageBuilder = apply { this.linkValue = link }
+    override fun link(link: String): RssImageBuilder = apply { this.link = link }
 
     override fun width(width: Int?): RssImageBuilder = apply { this.width = width }
 
@@ -28,7 +28,7 @@ internal class ValidatingRssImageBuilder : RssImageBuilder {
     override fun description(description: String?): RssImageBuilder = apply { this.description = description }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::urlValue.isInitialized && ::titleValue.isInitialized && ::linkValue.isInitialized
+        get() = url != null && title != null && link != null
 
     override fun build(): RssImage? {
         if (!hasEnoughDataToBuild) {
@@ -36,12 +36,39 @@ internal class ValidatingRssImageBuilder : RssImageBuilder {
         }
 
         return RssImage(
-            url = urlValue,
-            title = titleValue,
-            link = linkValue,
+            url = checkRequiredProperty(::url),
+            title = checkRequiredProperty(::title),
+            link = checkRequiredProperty(::link),
             width = width,
             height = height,
             description = description
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingRssImageBuilder) return false
+
+        if (url != other.url) return false
+        if (title != other.title) return false
+        if (link != other.link) return false
+        if (width != other.width) return false
+        if (height != other.height) return false
+        if (description != other.description) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url.hashCode()
+        result = 31 * result + title.hashCode()
+        result = 31 * result + link.hashCode()
+        result = 31 * result + (width ?: 0)
+        result = 31 * result + (height ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingRssImageBuilder(url='$url', title='$title', link='$link', width=$width, height=$height, description=$description)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/ValidatingUtils.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/ValidatingUtils.kt
@@ -1,0 +1,57 @@
+package dev.stalla.builder.validating
+
+import dev.stalla.builder.Builder
+import dev.stalla.util.InternalAPI
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Checks if the given nullable property, which is semantically required, is null.
+ *
+ * @param property The nullable but semantically required property to check.
+ * @param clarification A short message to append to the exception message in case the property value
+ * is null. Defaults to `${propertyName} is missing`.
+ * @return If the property value is null, it throws an [IllegalArgumentException]; otherwise, it
+ * returns the non-null value of the property.
+ */
+@InternalAPI
+@Suppress("unused") // The receiver is used to limit the scope of this function
+internal fun <T> Builder<*>.checkRequiredProperty(
+    property: KProperty<T?>,
+    clarification: String? = "${property.name} is missing"
+) = checkRequiredValue(property.obtainValue(), clarification)
+
+private fun <T> KProperty<T?>.obtainValue(): T? {
+    val wasAccessible = isAccessible
+    isAccessible = true
+    val value = call()
+    isAccessible = wasAccessible
+    return value
+}
+
+/**
+ * Checks if the given nullable value, which is semantically required not to be null, is null.
+ *
+ * @param value The nullable but semantically required value to check.
+ * @param clarification A short message to append to the exception message in case the value is
+ * null. Will be skipped if null or blank.
+ * @return If the value is null, it throws an [IllegalArgumentException]; otherwise, it returns
+ * the non-null value itself.
+ */
+@InternalAPI
+@Suppress("unused") // The receiver is used to limit the scope of this function
+internal fun <T> Builder<*>.checkRequiredValue(
+    value: T?,
+    clarification: String?
+) = requireNotNull(value) {
+    buildString {
+        val entityName = this::class.simpleName?.substringBeforeLast("Builder")
+            ?: "entity (ANONYMOUS)"
+        append("Cannot build the $entityName even though hasEnoughDataToBuild == true")
+        if (!clarification.isNullOrBlank()) {
+            append(" (")
+            append(clarification)
+            append(")")
+        }
+    }
+}

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeBitloveBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeBitloveBuilder.kt
@@ -1,24 +1,38 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodeBitloveBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.bitlove.Bitlove
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingEpisodeBitloveBuilder : EpisodeBitloveBuilder {
 
-    private lateinit var guidValue: String
+    private var guid: String? = null
 
-    override fun guid(guid: String): EpisodeBitloveBuilder = apply { this.guidValue = guid }
+    override fun guid(guid: String): EpisodeBitloveBuilder = apply { this.guid = guid }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::guidValue.isInitialized
+        get() = guid != null
 
     override fun build(): Bitlove? {
         if (!hasEnoughDataToBuild) {
             return null
         }
 
-        return Bitlove(guid = guidValue)
+        return Bitlove(guid = checkRequiredProperty(::guid))
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodeBitloveBuilder) return false
+
+        if (guid != other.guid) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = guid.hashCode()
+
+    override fun toString(): String = "ValidatingEpisodeBitloveBuilder(guid='$guid')"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeContentBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeContentBuilder.kt
@@ -1,24 +1,38 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodeContentBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.content.Content
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingEpisodeContentBuilder : EpisodeContentBuilder {
 
-    private lateinit var encodedValue: String
+    private var encoded: String? = null
 
-    override fun encoded(encoded: String): EpisodeContentBuilder = apply { this.encodedValue = encoded }
+    override fun encoded(encoded: String): EpisodeContentBuilder = apply { this.encoded = encoded }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::encodedValue.isInitialized
+        get() = encoded != null
 
     override fun build(): Content? {
         if (!hasEnoughDataToBuild) {
             return null
         }
 
-        return Content(encoded = encodedValue)
+        return Content(encoded = checkRequiredProperty(::encoded))
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodeContentBuilder) return false
+
+        if (encoded != other.encoded) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = encoded.hashCode()
+
+    override fun toString(): String = "ValidatingEpisodeContentBuilder(encodedValue='$encoded')"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeEnclosureBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeEnclosureBuilder.kt
@@ -1,6 +1,7 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodeEnclosureBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.MediaType
 import dev.stalla.model.rss.Enclosure
 import dev.stalla.util.InternalAPI
@@ -8,18 +9,18 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingEpisodeEnclosureBuilder : EpisodeEnclosureBuilder {
 
-    private lateinit var urlValue: String
-    private var lengthValue: Long = -1
-    private lateinit var typeValue: MediaType
+    private var url: String? = null
+    private var length: Long? = null
+    private var type: MediaType? = null
 
-    override fun url(url: String): EpisodeEnclosureBuilder = apply { this.urlValue = url }
+    override fun url(url: String): EpisodeEnclosureBuilder = apply { this.url = url }
 
-    override fun length(length: Long): EpisodeEnclosureBuilder = apply { this.lengthValue = length }
+    override fun length(length: Long): EpisodeEnclosureBuilder = apply { this.length = length }
 
-    override fun type(type: MediaType): EpisodeEnclosureBuilder = apply { this.typeValue = type }
+    override fun type(type: MediaType): EpisodeEnclosureBuilder = apply { this.type = type }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::urlValue.isInitialized && lengthValue >= 0 && ::typeValue.isInitialized
+        get() = url != null && length != null && type != null
 
     override fun build(): Enclosure? {
         if (!hasEnoughDataToBuild) {
@@ -27,9 +28,29 @@ internal class ValidatingEpisodeEnclosureBuilder : EpisodeEnclosureBuilder {
         }
 
         return Enclosure(
-            url = urlValue,
-            length = lengthValue,
-            type = typeValue
+            url = checkRequiredProperty(::url),
+            length = checkRequiredProperty(::length),
+            type = checkRequiredProperty(::type)
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodeEnclosureBuilder) return false
+
+        if (url != other.url) return false
+        if (length != other.length) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url.hashCode()
+        result = 31 * result + length.hashCode()
+        result = 31 * result + type.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "ValidatingEpisodeEnclosureBuilder(url='$url', length=$length, type=$type)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeGoogleplayBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeGoogleplayBuilder.kt
@@ -43,4 +43,29 @@ internal class ValidatingEpisodeGoogleplayBuilder : EpisodeGoogleplayBuilder {
             image = imageBuilder?.build()
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodeGoogleplayBuilder) return false
+
+        if (author != other.author) return false
+        if (description != other.description) return false
+        if (explicit != other.explicit) return false
+        if (block != other.block) return false
+        if (imageBuilder != other.imageBuilder) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = author?.hashCode() ?: 0
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (explicit?.hashCode() ?: 0)
+        result = 31 * result + block.hashCode()
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingEpisodeGoogleplayBuilder(author=$author, description=$description, explicit=$explicit, block=$block, imageBuilder=$imageBuilder)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeGuidBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeGuidBuilder.kt
@@ -1,13 +1,14 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodeGuidBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.rss.Guid
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingEpisodeGuidBuilder : EpisodeGuidBuilder {
 
-    private lateinit var text: String
+    private var text: String? = null
 
     private var isPermalink: Boolean? = null
 
@@ -16,7 +17,7 @@ internal class ValidatingEpisodeGuidBuilder : EpisodeGuidBuilder {
     override fun isPermalink(isPermalink: Boolean?): EpisodeGuidBuilder = apply { this.isPermalink = isPermalink }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::text.isInitialized
+        get() = text != null
 
     override fun build(): Guid? {
         if (!hasEnoughDataToBuild) {
@@ -24,8 +25,26 @@ internal class ValidatingEpisodeGuidBuilder : EpisodeGuidBuilder {
         }
 
         return Guid(
-            guid = text,
+            guid = checkRequiredProperty(::text, "guid text is missing"),
             isPermalink = isPermalink
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodeGuidBuilder) return false
+
+        if (text != other.text) return false
+        if (isPermalink != other.isPermalink) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = text.hashCode()
+        result = 31 * result + (isPermalink?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String = "ValidatingEpisodeGuidBuilder(text='$text', isPermalink=$isPermalink)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeItunesBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodeItunesBuilder.kt
@@ -71,4 +71,42 @@ internal class ValidatingEpisodeItunesBuilder : EpisodeItunesBuilder {
             summary = summary
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodeItunesBuilder) return false
+
+        if (title != other.title) return false
+        if (duration != other.duration) return false
+        if (imageBuilder != other.imageBuilder) return false
+        if (explicit != other.explicit) return false
+        if (block != other.block) return false
+        if (season != other.season) return false
+        if (episode != other.episode) return false
+        if (episodeType != other.episodeType) return false
+        if (author != other.author) return false
+        if (subtitle != other.subtitle) return false
+        if (summary != other.summary) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = title?.hashCode() ?: 0
+        result = 31 * result + (duration?.hashCode() ?: 0)
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        result = 31 * result + (explicit?.hashCode() ?: 0)
+        result = 31 * result + block.hashCode()
+        result = 31 * result + (season ?: 0)
+        result = 31 * result + (episode ?: 0)
+        result = 31 * result + (episodeType?.hashCode() ?: 0)
+        result = 31 * result + (author?.hashCode() ?: 0)
+        result = 31 * result + (subtitle?.hashCode() ?: 0)
+        result = 31 * result + (summary?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingEpisodeItunesBuilder(title=$title, duration=$duration, imageBuilder=$imageBuilder, explicit=$explicit, block=$block, " +
+            "season=$season, episode=$episode, episodeType=$episodeType, author=$author, subtitle=$subtitle, summary=$summary)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexBuilder.kt
@@ -46,4 +46,26 @@ internal class ValidatingEpisodePodcastindexBuilder : EpisodePodcastindexBuilder
             chapters = chaptersBuilderValue?.build()
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodePodcastindexBuilder) return false
+
+        if (chaptersBuilderValue != other.chaptersBuilderValue) return false
+        if (transcriptBuilders != other.transcriptBuilders) return false
+        if (soundbiteBuilders != other.soundbiteBuilders) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = chaptersBuilderValue?.hashCode() ?: 0
+        result = 31 * result + transcriptBuilders.hashCode()
+        result = 31 * result + soundbiteBuilders.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingEpisodePodcastindexBuilder(chaptersBuilderValue=$chaptersBuilderValue, transcriptBuilders=$transcriptBuilders, " +
+            "soundbiteBuilders=$soundbiteBuilders)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexChaptersBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexChaptersBuilder.kt
@@ -1,6 +1,7 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodePodcastindexChaptersBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.MediaType
 import dev.stalla.model.podcastindex.Chapters
 import dev.stalla.util.InternalAPI
@@ -8,15 +9,15 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingEpisodePodcastindexChaptersBuilder : EpisodePodcastindexChaptersBuilder {
 
-    private lateinit var urlValue: String
-    private lateinit var typeValue: MediaType
+    private var url: String? = null
+    private var type: MediaType? = null
 
-    override fun url(url: String): EpisodePodcastindexChaptersBuilder = apply { this.urlValue = url }
+    override fun url(url: String): EpisodePodcastindexChaptersBuilder = apply { this.url = url }
 
-    override fun type(type: MediaType): EpisodePodcastindexChaptersBuilder = apply { this.typeValue = type }
+    override fun type(type: MediaType): EpisodePodcastindexChaptersBuilder = apply { this.type = type }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::urlValue.isInitialized && ::typeValue.isInitialized
+        get() = url != null && type != null
 
     override fun build(): Chapters? {
         if (!hasEnoughDataToBuild) {
@@ -24,8 +25,26 @@ internal class ValidatingEpisodePodcastindexChaptersBuilder : EpisodePodcastinde
         }
 
         return Chapters(
-            url = urlValue,
-            type = typeValue
+            url = checkRequiredProperty(::url),
+            type = checkRequiredProperty(::type)
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodePodcastindexChaptersBuilder) return false
+
+        if (url != other.url) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url.hashCode()
+        result = 31 * result + type.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "ValidatingEpisodePodcastindexChaptersBuilder(url='$url', type=$type)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexSoundbiteBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexSoundbiteBuilder.kt
@@ -1,6 +1,7 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodePodcastindexSoundbiteBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.StyledDuration
 import dev.stalla.model.podcastindex.Soundbite
 import dev.stalla.util.InternalAPI
@@ -8,35 +9,59 @@ import dev.stalla.util.InternalAPI
 @InternalAPI
 internal class ValidatingEpisodePodcastindexSoundbiteBuilder : EpisodePodcastindexSoundbiteBuilder {
 
-    private lateinit var startTimeValue: StyledDuration.SecondsAndFraction
-    private lateinit var durationValue: StyledDuration.SecondsAndFraction
+    private var startTime: StyledDuration.SecondsAndFraction? = null
+    private var duration: StyledDuration.SecondsAndFraction? = null
 
     private var title: String? = null
 
     override fun startTime(startTime: StyledDuration.SecondsAndFraction): EpisodePodcastindexSoundbiteBuilder =
-        apply { this.startTimeValue = startTime }
+        apply { this.startTime = startTime }
 
     override fun duration(duration: StyledDuration.SecondsAndFraction): EpisodePodcastindexSoundbiteBuilder =
-        apply { this.durationValue = duration }
+        apply { this.duration = duration }
 
     override fun title(title: String?): EpisodePodcastindexSoundbiteBuilder = apply { this.title = title }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::startTimeValue.isInitialized && ::durationValue.isInitialized
+        get() = startTime != null && duration != null
 
     override fun build(): Soundbite? {
         if (!hasEnoughDataToBuild) {
             return null
         }
 
-        if (startTimeValue.isNegative || durationValue.isNegative || durationValue.isZero) {
+        val startTimeValid = checkRequiredProperty(::startTime, "start time is missing")
+        val durationValid = checkRequiredProperty(::duration)
+
+        if (startTimeValid.isNegative || durationValid.isNegative || durationValid.isZero) {
             return null
         }
 
         return Soundbite(
-            startTime = startTimeValue,
-            duration = durationValue,
+            startTime = startTimeValid,
+            duration = durationValid,
             title = title
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodePodcastindexSoundbiteBuilder) return false
+
+        if (startTime != other.startTime) return false
+        if (duration != other.duration) return false
+        if (title != other.title) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = startTime.hashCode()
+        result = 31 * result + duration.hashCode()
+        result = 31 * result + (title?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingEpisodePodcastindexSoundbiteBuilder(startTime=$startTime, duration=$duration, title=$title)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexTranscriptBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodcastindexTranscriptBuilder.kt
@@ -1,6 +1,7 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodePodcastindexTranscriptBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.podcastindex.Transcript
 import dev.stalla.model.podcastindex.TranscriptType
 import dev.stalla.util.InternalAPI
@@ -9,22 +10,22 @@ import java.util.Locale
 @InternalAPI
 internal class ValidatingEpisodePodcastindexTranscriptBuilder : EpisodePodcastindexTranscriptBuilder {
 
-    private lateinit var urlValue: String
-    private lateinit var typeValue: TranscriptType
+    private var url: String? = null
+    private var type: TranscriptType? = null
 
     private var language: Locale? = null
     private var rel: String? = null
 
-    override fun url(url: String): EpisodePodcastindexTranscriptBuilder = apply { this.urlValue = url }
+    override fun url(url: String): EpisodePodcastindexTranscriptBuilder = apply { this.url = url }
 
-    override fun type(type: TranscriptType): EpisodePodcastindexTranscriptBuilder = apply { this.typeValue = type }
+    override fun type(type: TranscriptType): EpisodePodcastindexTranscriptBuilder = apply { this.type = type }
 
     override fun language(language: Locale?): EpisodePodcastindexTranscriptBuilder = apply { this.language = language }
 
     override fun rel(rel: String?): EpisodePodcastindexTranscriptBuilder = apply { this.rel = rel }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::urlValue.isInitialized && ::typeValue.isInitialized
+        get() = url != null && type != null
 
     override fun build(): Transcript? {
         if (!hasEnoughDataToBuild) {
@@ -32,10 +33,33 @@ internal class ValidatingEpisodePodcastindexTranscriptBuilder : EpisodePodcastin
         }
 
         return Transcript(
-            url = urlValue,
-            type = typeValue,
+            url = checkRequiredProperty(::url),
+            type = checkRequiredProperty(::type),
             language = language,
             rel = rel
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodePodcastindexTranscriptBuilder) return false
+
+        if (url != other.url) return false
+        if (type != other.type) return false
+        if (language != other.language) return false
+        if (rel != other.rel) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url.hashCode()
+        result = 31 * result + type.hashCode()
+        result = 31 * result + (language?.hashCode() ?: 0)
+        result = 31 * result + (rel?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingEpisodePodcastindexTranscriptBuilder(url='$url', type=$type, language=$language, rel=$rel)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodloveBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodloveBuilder.kt
@@ -32,4 +32,17 @@ internal class ValidatingEpisodePodloveBuilder : EpisodePodloveBuilder {
             simpleChapters = chapterBuilders.mapNotNull { it.build() }.asUnmodifiable()
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodePodloveBuilder) return false
+
+        if (chapterBuilders != other.chapterBuilders) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = chapterBuilders.hashCode()
+
+    override fun toString(): String = "ValidatingEpisodePodloveBuilder(chapterBuilders=$chapterBuilders)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodloveSimpleChapterBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/episode/ValidatingEpisodePodloveSimpleChapterBuilder.kt
@@ -1,28 +1,29 @@
 package dev.stalla.builder.validating.episode
 
 import dev.stalla.builder.episode.EpisodePodloveSimpleChapterBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.podlove.SimpleChapter
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingEpisodePodloveSimpleChapterBuilder : EpisodePodloveSimpleChapterBuilder {
 
-    private lateinit var startValue: String
-    private lateinit var titleValue: String
+    private var start: String? = null
+    private var title: String? = null
 
     private var href: String? = null
     private var image: String? = null
 
-    override fun start(start: String): EpisodePodloveSimpleChapterBuilder = apply { this.startValue = start }
+    override fun start(start: String): EpisodePodloveSimpleChapterBuilder = apply { this.start = start }
 
-    override fun title(title: String): EpisodePodloveSimpleChapterBuilder = apply { this.titleValue = title }
+    override fun title(title: String): EpisodePodloveSimpleChapterBuilder = apply { this.title = title }
 
     override fun href(href: String?): EpisodePodloveSimpleChapterBuilder = apply { this.href = href }
 
     override fun image(image: String?): EpisodePodloveSimpleChapterBuilder = apply { this.image = image }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::startValue.isInitialized && ::titleValue.isInitialized
+        get() = start != null && title != null
 
     override fun build(): SimpleChapter? {
         if (!hasEnoughDataToBuild) {
@@ -30,10 +31,33 @@ internal class ValidatingEpisodePodloveSimpleChapterBuilder : EpisodePodloveSimp
         }
 
         return SimpleChapter(
-            start = startValue,
-            title = titleValue,
+            start = checkRequiredProperty(::start),
+            title = checkRequiredProperty(::title),
             href = href,
             image = image
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingEpisodePodloveSimpleChapterBuilder) return false
+
+        if (start != other.start) return false
+        if (title != other.title) return false
+        if (href != other.href) return false
+        if (image != other.image) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = start.hashCode()
+        result = 31 * result + title.hashCode()
+        result = 31 * result + (href?.hashCode() ?: 0)
+        result = 31 * result + (image?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString() =
+        "ValidatingEpisodePodloveSimpleChapterBuilder(start='$start', title='$title', href=$href, image=$image)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastBuilder.kt
@@ -23,6 +23,7 @@ import dev.stalla.builder.validating.ValidatingHrefOnlyImageBuilder
 import dev.stalla.builder.validating.ValidatingLinkBuilder
 import dev.stalla.builder.validating.ValidatingRssCategoryBuilder
 import dev.stalla.builder.validating.ValidatingRssImageBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.Podcast
 import dev.stalla.util.InternalAPI
 import dev.stalla.util.asUnmodifiable
@@ -32,10 +33,10 @@ import java.util.Locale
 @InternalAPI
 internal class ValidatingPodcastBuilder : ProvidingPodcastBuilder {
 
-    private lateinit var titleValue: String
-    private lateinit var linkValue: String
-    private lateinit var descriptionValue: String
-    private lateinit var languageValue: Locale
+    private var title: String? = null
+    private var link: String? = null
+    private var description: String? = null
+    private var language: Locale? = null
 
     private var pubDate: TemporalAccessor? = null
     private var lastBuildDate: TemporalAccessor? = null
@@ -62,18 +63,18 @@ internal class ValidatingPodcastBuilder : ProvidingPodcastBuilder {
 
     override val podcastPodcastindexBuilder: PodcastPodcastindexBuilder = ValidatingPodcastPodcastindexBuilder()
 
-    override fun title(title: String): PodcastBuilder = apply { this.titleValue = title }
+    override fun title(title: String): PodcastBuilder = apply { this.title = title }
 
-    override fun link(link: String): PodcastBuilder = apply { this.linkValue = link }
+    override fun link(link: String): PodcastBuilder = apply { this.link = link }
 
-    override fun description(description: String): PodcastBuilder = apply { this.descriptionValue = description }
+    override fun description(description: String): PodcastBuilder = apply { this.description = description }
 
     override fun pubDate(pubDate: TemporalAccessor?): PodcastBuilder = apply { this.pubDate = pubDate }
 
     override fun lastBuildDate(lastBuildDate: TemporalAccessor?): PodcastBuilder =
         apply { this.lastBuildDate = lastBuildDate }
 
-    override fun language(language: Locale): PodcastBuilder = apply { this.languageValue = language }
+    override fun language(language: Locale): PodcastBuilder = apply { this.language = language }
 
     override fun generator(generator: String?): PodcastBuilder = apply { this.generator = generator }
 
@@ -117,8 +118,8 @@ internal class ValidatingPodcastBuilder : ProvidingPodcastBuilder {
 
     override val hasEnoughDataToBuild: Boolean
         get() = episodeBuilders.any { it.hasEnoughDataToBuild } &&
-            ::titleValue.isInitialized && ::descriptionValue.isInitialized &&
-            ::linkValue.isInitialized && ::languageValue.isInitialized
+            title != null && description != null &&
+            link != null && language != null
 
     override fun build(): Podcast? {
         if (!hasEnoughDataToBuild) {
@@ -126,12 +127,12 @@ internal class ValidatingPodcastBuilder : ProvidingPodcastBuilder {
         }
 
         return Podcast(
-            title = titleValue,
-            link = linkValue,
-            description = descriptionValue,
+            title = checkRequiredProperty(::title),
+            link = checkRequiredProperty(::link),
+            description = checkRequiredProperty(::description),
             pubDate = pubDate,
             lastBuildDate = lastBuildDate,
-            language = languageValue,
+            language = checkRequiredProperty(::language),
             generator = generator,
             copyright = copyright,
             docs = docs,
@@ -149,4 +150,66 @@ internal class ValidatingPodcastBuilder : ProvidingPodcastBuilder {
             podcastindex = podcastPodcastindexBuilder.build()
         )
     }
+
+    @Suppress("ComplexMethod") // It's an equals
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingPodcastBuilder) return false
+
+        if (title != other.title) return false
+        if (link != other.link) return false
+        if (description != other.description) return false
+        if (language != other.language) return false
+        if (pubDate != other.pubDate) return false
+        if (lastBuildDate != other.lastBuildDate) return false
+        if (generator != other.generator) return false
+        if (copyright != other.copyright) return false
+        if (docs != other.docs) return false
+        if (managingEditor != other.managingEditor) return false
+        if (webMaster != other.webMaster) return false
+        if (ttl != other.ttl) return false
+        if (imageBuilder != other.imageBuilder) return false
+        if (categoryBuilders != other.categoryBuilders) return false
+        if (episodeBuilders != other.episodeBuilders) return false
+        if (itunesBuilder != other.itunesBuilder) return false
+        if (atomBuilder != other.atomBuilder) return false
+        if (fyydBuilder != other.fyydBuilder) return false
+        if (feedpressBuilder != other.feedpressBuilder) return false
+        if (googleplayBuilder != other.googleplayBuilder) return false
+        if (podcastPodcastindexBuilder != other.podcastPodcastindexBuilder) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = title.hashCode()
+        result = 31 * result + link.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + language.hashCode()
+        result = 31 * result + (pubDate?.hashCode() ?: 0)
+        result = 31 * result + (lastBuildDate?.hashCode() ?: 0)
+        result = 31 * result + (generator?.hashCode() ?: 0)
+        result = 31 * result + (copyright?.hashCode() ?: 0)
+        result = 31 * result + (docs?.hashCode() ?: 0)
+        result = 31 * result + (managingEditor?.hashCode() ?: 0)
+        result = 31 * result + (webMaster?.hashCode() ?: 0)
+        result = 31 * result + (ttl ?: 0)
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        result = 31 * result + categoryBuilders.hashCode()
+        result = 31 * result + episodeBuilders.hashCode()
+        result = 31 * result + itunesBuilder.hashCode()
+        result = 31 * result + atomBuilder.hashCode()
+        result = 31 * result + fyydBuilder.hashCode()
+        result = 31 * result + feedpressBuilder.hashCode()
+        result = 31 * result + googleplayBuilder.hashCode()
+        result = 31 * result + podcastPodcastindexBuilder.hashCode()
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingPodcastBuilder(title='$title', link='$link', description='$description', language=$language, pubDate=$pubDate, " +
+            "lastBuildDate=$lastBuildDate, generator=$generator, copyright=$copyright, docs=$docs, managingEditor=$managingEditor, " +
+            "webMaster=$webMaster, ttl=$ttl, imageBuilder=$imageBuilder, categoryBuilders=$categoryBuilders, episodeBuilders=$episodeBuilders, " +
+            "itunesBuilder=$itunesBuilder, atomBuilder=$atomBuilder, fyydBuilder=$fyydBuilder, feedpressBuilder=$feedpressBuilder, " +
+            "googleplayBuilder=$googleplayBuilder, podcastPodcastindexBuilder=$podcastPodcastindexBuilder)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastFeedpressBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastFeedpressBuilder.kt
@@ -42,4 +42,29 @@ internal class ValidatingPodcastFeedpressBuilder : PodcastFeedpressBuilder {
             link = link
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingPodcastFeedpressBuilder) return false
+
+        if (newsletterId != other.newsletterId) return false
+        if (locale != other.locale) return false
+        if (podcastId != other.podcastId) return false
+        if (cssFile != other.cssFile) return false
+        if (link != other.link) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = newsletterId?.hashCode() ?: 0
+        result = 31 * result + (locale?.hashCode() ?: 0)
+        result = 31 * result + (podcastId?.hashCode() ?: 0)
+        result = 31 * result + (cssFile?.hashCode() ?: 0)
+        result = 31 * result + (link?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingPodcastFeedpressBuilder(newsletterId=$newsletterId, locale=$locale, podcastId=$podcastId, cssFile=$cssFile, link=$link)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastFyydBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastFyydBuilder.kt
@@ -1,24 +1,38 @@
 package dev.stalla.builder.validating.podcast
 
 import dev.stalla.builder.podcast.PodcastFyydBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.fyyd.Fyyd
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingPodcastFyydBuilder : PodcastFyydBuilder {
 
-    private lateinit var verifyValue: String
+    private var verify: String? = null
 
-    override fun verify(verify: String): PodcastFyydBuilder = apply { this.verifyValue = verify }
+    override fun verify(verify: String): PodcastFyydBuilder = apply { this.verify = verify }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::verifyValue.isInitialized
+        get() = verify != null
 
     override fun build(): Fyyd? {
         if (!hasEnoughDataToBuild) {
             return null
         }
 
-        return Fyyd(verify = verifyValue)
+        return Fyyd(checkRequiredProperty(::verify))
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingPodcastFyydBuilder) return false
+
+        if (verify != other.verify) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = verify.hashCode()
+
+    override fun toString(): String = "ValidatingPodcastFyydBuilder(verify='$verify')"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastGoogleplayBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastGoogleplayBuilder.kt
@@ -62,4 +62,36 @@ internal class ValidatingPodcastGoogleplayBuilder : PodcastGoogleplayBuilder {
             newFeedUrl = newFeedUrl
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingPodcastGoogleplayBuilder) return false
+
+        if (author != other.author) return false
+        if (email != other.email) return false
+        if (categories != other.categories) return false
+        if (description != other.description) return false
+        if (explicit != other.explicit) return false
+        if (block != other.block) return false
+        if (imageBuilder != other.imageBuilder) return false
+        if (newFeedUrl != other.newFeedUrl) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = author?.hashCode() ?: 0
+        result = 31 * result + (email?.hashCode() ?: 0)
+        result = 31 * result + categories.hashCode()
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (explicit?.hashCode() ?: 0)
+        result = 31 * result + block.hashCode()
+        result = 31 * result + (imageBuilder?.hashCode() ?: 0)
+        result = 31 * result + (newFeedUrl?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ValidatingPodcastGoogleplayBuilder(author=$author, email=$email, categories=$categories, description=$description, explicit=$explicit, " +
+            "block=$block, imageBuilder=$imageBuilder, newFeedUrl=$newFeedUrl)"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastItunesOwnerBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastItunesOwnerBuilder.kt
@@ -1,21 +1,22 @@
 package dev.stalla.builder.validating.podcast
 
 import dev.stalla.builder.podcast.PodcastItunesOwnerBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.itunes.ItunesOwner
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingPodcastItunesOwnerBuilder : PodcastItunesOwnerBuilder {
 
-    private lateinit var nameValue: String
-    private lateinit var emailValue: String
+    private var name: String? = null
+    private var email: String? = null
 
-    override fun name(name: String): PodcastItunesOwnerBuilder = apply { this.nameValue = name }
+    override fun name(name: String): PodcastItunesOwnerBuilder = apply { this.name = name }
 
-    override fun email(email: String): PodcastItunesOwnerBuilder = apply { this.emailValue = email }
+    override fun email(email: String): PodcastItunesOwnerBuilder = apply { this.email = email }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::nameValue.isInitialized && ::emailValue.isInitialized
+        get() = name != null && email != null
 
     override fun build(): ItunesOwner? {
         if (!hasEnoughDataToBuild) {
@@ -23,8 +24,26 @@ internal class ValidatingPodcastItunesOwnerBuilder : PodcastItunesOwnerBuilder {
         }
 
         return ItunesOwner(
-            name = nameValue,
-            email = emailValue
+            name = checkRequiredProperty(::name),
+            email = checkRequiredProperty(::email)
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingPodcastItunesOwnerBuilder) return false
+
+        if (name != other.name) return false
+        if (email != other.email) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + email.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "ValidatingPodcastItunesOwnerBuilder(name='$name', email='$email')"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastPodcastindexFundingBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastPodcastindexFundingBuilder.kt
@@ -1,21 +1,22 @@
 package dev.stalla.builder.validating.podcast
 
 import dev.stalla.builder.podcast.PodcastPodcastindexFundingBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.podcastindex.Funding
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingPodcastPodcastindexFundingBuilder : PodcastPodcastindexFundingBuilder {
 
-    private lateinit var urlValue: String
-    private lateinit var messageValue: String
+    private var url: String? = null
+    private var message: String? = null
 
-    override fun url(url: String): PodcastPodcastindexFundingBuilder = apply { this.urlValue = url }
+    override fun url(url: String): PodcastPodcastindexFundingBuilder = apply { this.url = url }
 
-    override fun message(message: String): PodcastPodcastindexFundingBuilder = apply { this.messageValue = message }
+    override fun message(message: String): PodcastPodcastindexFundingBuilder = apply { this.message = message }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::urlValue.isInitialized && ::messageValue.isInitialized
+        get() = url != null && message != null
 
     override fun build(): Funding? {
         if (!hasEnoughDataToBuild) {
@@ -23,8 +24,26 @@ internal class ValidatingPodcastPodcastindexFundingBuilder : PodcastPodcastindex
         }
 
         return Funding(
-            url = urlValue,
-            message = messageValue
+            url = checkRequiredProperty(::url),
+            message = checkRequiredProperty(::message)
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingPodcastPodcastindexFundingBuilder) return false
+
+        if (url != other.url) return false
+        if (message != other.message) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = url.hashCode()
+        result = 31 * result + message.hashCode()
+        return result
+    }
+
+    override fun toString(): String = "ValidatingPodcastPodcastindexFundingBuilder(url='$url', message='$message')"
 }

--- a/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastPodcastindexLockedBuilder.kt
+++ b/src/main/kotlin/dev/stalla/builder/validating/podcast/ValidatingPodcastPodcastindexLockedBuilder.kt
@@ -1,21 +1,22 @@
 package dev.stalla.builder.validating.podcast
 
 import dev.stalla.builder.podcast.PodcastPodcastindexLockedBuilder
+import dev.stalla.builder.validating.checkRequiredProperty
 import dev.stalla.model.podcastindex.Locked
 import dev.stalla.util.InternalAPI
 
 @InternalAPI
 internal class ValidatingPodcastPodcastindexLockedBuilder : PodcastPodcastindexLockedBuilder {
 
-    private lateinit var ownerValue: String
+    private var owner: String? = null
     private var locked: Boolean? = null
 
-    override fun owner(owner: String): PodcastPodcastindexLockedBuilder = apply { this.ownerValue = owner }
+    override fun owner(owner: String): PodcastPodcastindexLockedBuilder = apply { this.owner = owner }
 
     override fun locked(locked: Boolean): PodcastPodcastindexLockedBuilder = apply { this.locked = locked }
 
     override val hasEnoughDataToBuild: Boolean
-        get() = ::ownerValue.isInitialized && locked != null
+        get() = owner != null && locked != null
 
     override fun build(): Locked? {
         if (!hasEnoughDataToBuild) {
@@ -23,9 +24,26 @@ internal class ValidatingPodcastPodcastindexLockedBuilder : PodcastPodcastindexL
         }
 
         return Locked(
-            owner = ownerValue,
-            locked = locked
-                ?: error("The locked flag is not set, while hasEnoughDataToBuild == true")
+            owner = checkRequiredProperty(::owner),
+            locked = checkRequiredProperty(::locked)
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ValidatingPodcastPodcastindexLockedBuilder) return false
+
+        if (owner != other.owner) return false
+        if (locked != other.locked) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = owner.hashCode()
+        result = 31 * result + (locked?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String = "ValidatingPodcastPodcastindexLockedBuilder(owner='$owner', locked=$locked)"
 }

--- a/src/main/kotlin/dev/stalla/util/CollectionsExtensions.kt
+++ b/src/main/kotlin/dev/stalla/util/CollectionsExtensions.kt
@@ -19,40 +19,40 @@ import java.util.Collections
 /** Transforms this list into a list of [RssCategoryBuilder]. */
 @InternalAPI
 @JvmName("asRssCategoryBuilders")
-internal fun List<RssCategory>.asBuilders(): List<RssCategoryBuilder> = map(RssCategory.builder()::applyFrom)
+internal fun List<RssCategory>.asBuilders(): List<RssCategoryBuilder> = map { RssCategory.builder().applyFrom(it) }
 
 /** Transforms this list into a list of [EpisodeEnclosureBuilder]. */
 @InternalAPI
 @JvmName("asEnclosureBuilders")
-internal fun List<Enclosure>.asBuilders(): List<EpisodeEnclosureBuilder> = map(Enclosure.builder()::applyFrom)
+internal fun List<Enclosure>.asBuilders(): List<EpisodeEnclosureBuilder> = map { Enclosure.builder().applyFrom(it) }
 
 /** Transforms this list into a list of [EpisodePodcastindexSoundbiteBuilder]. */
 @InternalAPI
 @JvmName("asSoundbiteBuilders")
 internal fun List<Soundbite>.asBuilders(): List<EpisodePodcastindexSoundbiteBuilder> =
-    map(Soundbite.builder()::applyFrom)
+    map { Soundbite.builder().applyFrom(it) }
 
 /** Transforms this list into a list of [EpisodePodcastindexTranscriptBuilder]. */
 @InternalAPI
 @JvmName("asTranscriptBuilders")
 internal fun List<Transcript>.asBuilders(): List<EpisodePodcastindexTranscriptBuilder> =
-    map(Transcript.builder()::applyFrom)
+    map { Transcript.builder().applyFrom(it) }
 
 /** Transforms this list into a list of [PodcastPodcastindexFundingBuilder]. */
 @InternalAPI
 @JvmName("asFundingBuilders")
-internal fun List<Funding>.asBuilders(): List<PodcastPodcastindexFundingBuilder> = map(Funding.builder()::applyFrom)
+internal fun List<Funding>.asBuilders(): List<PodcastPodcastindexFundingBuilder> = map { Funding.builder().applyFrom(it) }
 
 /** Transforms this list into a list of [EpisodePodloveSimpleChapterBuilder]. */
 @InternalAPI
 @JvmName("asSimpleChapterBuilders")
 internal fun List<SimpleChapter>.asBuilders(): List<EpisodePodloveSimpleChapterBuilder> =
-    map(SimpleChapter.builder()::applyFrom)
+    map { SimpleChapter.builder().applyFrom(it) }
 
 /** Transforms this list into a list of [EpisodeBuilder]. */
 @InternalAPI
 @JvmName("asEpisodeBuilders")
-internal fun List<Episode>.asBuilders(): List<EpisodeBuilder> = map(Episode.builder()::applyFrom)
+internal fun List<Episode>.asBuilders(): List<EpisodeBuilder> = map { Episode.builder().applyFrom(it) }
 
 /** Returns an unmodifiable view of this list. */
 @InternalAPI

--- a/src/test/kotlin/dev/stalla/util/CollectionsExtensionsTest.kt
+++ b/src/test/kotlin/dev/stalla/util/CollectionsExtensionsTest.kt
@@ -1,0 +1,182 @@
+package dev.stalla.util
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import dev.stalla.model.Episode
+import dev.stalla.model.MediaType
+import dev.stalla.model.StyledDuration
+import dev.stalla.model.bitlove.Bitlove
+import dev.stalla.model.content.Content
+import dev.stalla.model.podcastindex.Funding
+import dev.stalla.model.podcastindex.Soundbite
+import dev.stalla.model.podcastindex.Transcript
+import dev.stalla.model.podcastindex.TranscriptType
+import dev.stalla.model.podlove.SimpleChapter
+import dev.stalla.model.rss.Enclosure
+import dev.stalla.model.rss.Guid
+import dev.stalla.model.rss.RssCategory
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class CollectionsExtensionsTest {
+
+    @Nested
+    inner class RssCategories {
+
+        @Test
+        internal fun `should transform all RssCategories to builders`() {
+            val rssCategories = listOf(
+                RssCategory("category 1", domain = null),
+                RssCategory("category 2", domain = "banana")
+            )
+
+            assertThat(rssCategories.asBuilders()).containsExactly(
+                RssCategory.builder().category("category 1"),
+                RssCategory.builder().category("category 2").domain("banana")
+            )
+        }
+    }
+
+    @Nested
+    inner class Enclosures {
+
+        @Test
+        internal fun `should transform all Enclosure to builders`() {
+            val enclosures = listOf(
+                Enclosure("url 1", 123L, MediaType.ANY_AUDIO),
+                Enclosure("url 2", 456L, MediaType.MPEG_AUDIO)
+            )
+
+            assertThat(enclosures.asBuilders()).containsExactly(
+                Enclosure.builder().url("url 1").length(123L).type(MediaType.ANY_AUDIO),
+                Enclosure.builder().url("url 2").length(456L).type(MediaType.MPEG_AUDIO)
+            )
+        }
+    }
+
+    @Nested
+    inner class SoundBites {
+
+        @Test
+        internal fun `should transform all SoundBite to builders`() {
+            val twoSeconds = StyledDuration.Factory.secondsAndFraction(seconds = 2)
+            val threeSeconds = StyledDuration.Factory.secondsAndFraction(seconds = 3)
+
+            val soundBites = listOf(
+                Soundbite(
+                    startTime = twoSeconds,
+                    duration = threeSeconds,
+                    title = "SoundBite 1"
+                ),
+                Soundbite(
+                    startTime = threeSeconds,
+                    duration = twoSeconds,
+                    title = "SoundBite 2"
+                ),
+            )
+
+            assertThat(soundBites.asBuilders()).containsExactly(
+                Soundbite.builder()
+                    .startTime(twoSeconds)
+                    .duration(threeSeconds)
+                    .title("SoundBite 1"),
+                Soundbite.builder()
+                    .startTime(threeSeconds)
+                    .duration(twoSeconds)
+                    .title("SoundBite 2"),
+            )
+        }
+    }
+
+    @Nested
+    inner class Transcripts {
+
+        @Test
+        internal fun `should transform all Transcript to builders`() {
+            val transcripts = listOf(
+                Transcript("url 1", TranscriptType.PLAIN_TEXT),
+                Transcript("url 2", TranscriptType.JSON, Locale.ITALIAN, "banana")
+            )
+
+            assertThat(transcripts.asBuilders()).containsExactly(
+                Transcript.builder().url("url 1").type(TranscriptType.PLAIN_TEXT),
+                Transcript.builder().url("url 2").type(TranscriptType.JSON).language(Locale.ITALIAN).rel("banana")
+            )
+        }
+    }
+
+    @Nested
+    inner class Fundings {
+
+        @Test
+        internal fun `should transform all Funding to builders`() {
+            val transcripts = listOf(
+                Funding("url 1", "message 1"),
+                Funding("url 2", "banana")
+            )
+
+            assertThat(transcripts.asBuilders()).containsExactly(
+                Funding.builder().url("url 1").message("message 1"),
+                Funding.builder().url("url 2").message("banana")
+            )
+        }
+    }
+
+    @Nested
+    inner class SimpleChapters {
+
+        @Test
+        internal fun `should transform all SimpleChapter to builders`() {
+            val simpleChapters = listOf(
+                SimpleChapter("start", "simple chapter 1"),
+                SimpleChapter("start", "simple chapter 2"),
+            )
+
+            assertThat(simpleChapters.asBuilders()).containsExactly(
+                SimpleChapter.builder().start("start").title("simple chapter 1"),
+                SimpleChapter.builder().start("start").title("simple chapter 2"),
+            )
+        }
+    }
+
+    @Nested
+    inner class Episodes {
+
+        @Test
+        internal fun `should transform all Episode to builders`() {
+            val episodes = listOf(
+                Episode(
+                    title = "episode 1",
+                    guid = Guid("1234"),
+                    enclosure = Enclosure("url 1", 123L, MediaType.ANY_AUDIO),
+                    content = Content("encoded 1"),
+                    bitlove = Bitlove("123")
+                ),
+                Episode(
+                    title = "episode 2",
+                    guid = Guid("5678"),
+                    enclosure = Enclosure("url 2", 123L, MediaType.ANY_AUDIO),
+                    content = Content("encoded 2"),
+                    bitlove = Bitlove("456")
+                ),
+            )
+
+            assertThat(episodes.asBuilders()).containsExactly(
+                Episode.builder()
+                    .title("episode 1")
+                    .guidBuilder(Guid.builder().textContent("1234"))
+                    .enclosureBuilder(Enclosure.builder().url("url 1").length(123L).type(MediaType.ANY_AUDIO)).apply {
+                        contentBuilder.encoded("encoded 1")
+                        bitloveBuilder.guid("123")
+                    },
+                Episode.builder().title("episode 2")
+                    .guidBuilder(Guid.builder().textContent("5678"))
+                    .enclosureBuilder(Enclosure.builder().url("url 2").length(123L).type(MediaType.ANY_AUDIO)).apply {
+                        contentBuilder.encoded("encoded 2")
+                        bitloveBuilder.guid("456")
+                    }
+            )
+        }
+    }
+}


### PR DESCRIPTION
They used to return a list made up of the same builder repeated `n` times, where `n` is the size of the source list, instead of n builders.

This requires a number of internal (non API breaking) changes to all validating builders.